### PR TITLE
db_field and @property AttributeError

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 9)
+VERSION = (0, 6, 10)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -780,6 +780,7 @@ class BaseDocument(object):
                     dynamic_data[key] = value
         else:
             for key, value in values.items():
+                key = self._reverse_db_field_map.get(key, key)
                 setattr(self, key, value)
 
         # Set any get_fieldname_display methods


### PR DESCRIPTION
If you have a field on a Document that uses a db_field value that is the
same as a property on the Document itself, then an AttributeError is
raised when trying to fetch that instance from Mongo.

https://github.com/MongoEngine/mongoengine/issues/26

Fix taken from:
https://github.com/MongoEngine/mongoengine/commit/9e7ea64bd2cc4b42494b574750ff2afa5e8237b8
