### PR TITLE
Explicitly depend on Conversocial pymongo fork

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 12)
+VERSION = (0, 6, 13)
 
 
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo'],
+      install_requires=['pymongo==2.5.0.2'],
+      dependency_links=[
+          "git+ssh://git@github.com/conversocial/mongo-python-driver.git@fcbc98de2a4b045924fccaa7608c628ebadc6946#egg=pymongo-2.5.0.2",
+      ],
       test_suite='tests',
       tests_require=['blinker', 'django>=1.3', 'pillow']
 )


### PR DESCRIPTION
Conflicts:

```
mongoengine/__init__.py
```
