### PR TITLE
DAF-44 — Coerce object ids to correct text type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,8 +80,9 @@ Some simple examples of what MongoEngine code looks like::
 
 Tests
 =====
-To run the test suite, ensure you are running a local instance of MongoDB on
-the standard port, and run ``python setup.py test``.
+- Ensure you are running a local instance of MongoDB on the standard port
+- Ensure you have ``tox`` installed (``pip install tox``)
+- Run ``tox``
 
 Community
 =========

--- a/benchmark.py
+++ b/benchmark.py
@@ -16,7 +16,7 @@ def cprofile_main():
     class Noddy(Document):
         fields = DictField()
 
-    for i in xrange(1):
+    for i in range(1):
         noddy = Noddy()
         for j in range(20):
             noddy.fields["key" + str(j)] = "value " + str(j)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
 
 import timeit
 
@@ -9,7 +10,7 @@ def cprofile_main():
     connection.drop_database('timeit_test')
     connection.disconnect()
 
-    from mongoengine import Document, DictField, connect
+    from .mongoengine import Document, DictField, connect
     connect("timeit_test")
 
     class Noddy(Document):
@@ -106,7 +107,7 @@ connection = Connection()
 connection.drop_database('timeit_test')
 connection.disconnect()
 
-from mongoengine import Document, DictField, connect
+from .mongoengine import Document, DictField, connect
 connect("timeit_test")
 
 class Noddy(Document):

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import timeit
 
@@ -96,10 +96,10 @@ myNoddys = noddy.find()
 [n for n in myNoddys] # iterate
 """
 
-    print "-" * 100
-    print """Creating 10000 dictionaries - Pymongo"""
+    print("-" * 100)
+    print("""Creating 10000 dictionaries - Pymongo""")
     t = timeit.Timer(stmt=stmt, setup=setup)
-    print t.timeit(1)
+    print(t.timeit(1))
 
     setup = """
 from pymongo import Connection
@@ -125,10 +125,10 @@ myNoddys = Noddy.objects()
 [n for n in myNoddys] # iterate
 """
 
-    print "-" * 100
-    print """Creating 10000 dictionaries - MongoEngine"""
+    print("-" * 100)
+    print("""Creating 10000 dictionaries - MongoEngine""")
     t = timeit.Timer(stmt=stmt, setup=setup)
-    print t.timeit(1)
+    print(t.timeit(1))
 
     stmt = """
 for i in xrange(10000):
@@ -141,10 +141,10 @@ myNoddys = Noddy.objects()
 [n for n in myNoddys] # iterate
 """
 
-    print "-" * 100
-    print """Creating 10000 dictionaries - MongoEngine, safe=False, validate=False"""
+    print("-" * 100)
+    print("""Creating 10000 dictionaries - MongoEngine, safe=False, validate=False""")
     t = timeit.Timer(stmt=stmt, setup=setup)
-    print t.timeit(1)
+    print(t.timeit(1))
 
 
     stmt = """
@@ -158,10 +158,10 @@ myNoddys = Noddy.objects()
 [n for n in myNoddys] # iterate
 """
 
-    print "-" * 100
-    print """Creating 10000 dictionaries - MongoEngine, safe=False, validate=False, cascade=False"""
+    print("-" * 100)
+    print("""Creating 10000 dictionaries - MongoEngine, safe=False, validate=False, cascade=False""")
     t = timeit.Timer(stmt=stmt, setup=setup)
-    print t.timeit(1)
+    print(t.timeit(1))
 
     stmt = """
 for i in xrange(10000):
@@ -174,10 +174,10 @@ myNoddys = Noddy.objects()
 [n for n in myNoddys] # iterate
 """
 
-    print "-" * 100
-    print """Creating 10000 dictionaries - MongoEngine, force=True"""
+    print("-" * 100)
+    print("""Creating 10000 dictionaries - MongoEngine, force=True""")
     t = timeit.Timer(stmt=stmt, setup=setup)
-    print t.timeit(1)
+    print(t.timeit(1))
 
 if __name__ == "__main__":
     main()

--- a/docs/code/tumblelog.py
+++ b/docs/code/tumblelog.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from mongoengine import *
 
 connect('tumblelog')
@@ -41,26 +43,26 @@ post2.link_url = 'http://tractiondigital.com/labs/mongoengine/docs'
 post2.tags = ['mongoengine']
 post2.save()
 
-print 'ALL POSTS'
-print
+print('ALL POSTS')
+print()
 for post in Post.objects:
-    print post.title
-    print '=' * len(post.title)
+    print(post.title)
+    print('=' * len(post.title))
 
     if isinstance(post, TextPost):
-        print post.content
+        print(post.content)
 
     if isinstance(post, LinkPost):
-        print 'Link:', post.link_url
+        print('Link:', post.link_url)
 
-    print
-print
+    print()
+print()
 
-print 'POSTS TAGGED \'MONGODB\''
-print
+print('POSTS TAGGED \'MONGODB\'')
+print()
 for post in Post.objects(tags='mongodb'):
-    print post.title
-print
+    print(post.title)
+print()
 
 num_posts = Post.objects(tags='mongodb').count()
-print 'Found %d posts with tag "mongodb"' % num_posts
+print('Found %d posts with tag "mongodb"' % num_posts)

--- a/docs/guide/signals.rst
+++ b/docs/guide/signals.rst
@@ -32,7 +32,7 @@ Example usage::
     class Author(Document):
         name = StringField()
 
-        def __unicode__(self):
+        def __str__(self):
             return self.name
 
         @classmethod

--- a/docs/guide/signals.rst
+++ b/docs/guide/signals.rst
@@ -9,11 +9,7 @@ Signal support is provided by the excellent `blinker`_ library and
 will gracefully fall back if it is not available.
 
 
-<<<<<<< HEAD
-The following document signals exist in MongoEngine and are pretty self explanatory:
-=======
 The following document signals exist in MongoEngine and are pretty self-explanatory:
->>>>>>> master
 
   * `mongoengine.signals.pre_init`
   * `mongoengine.signals.post_init`

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 24)
+VERSION = (0, 6, 25)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 26)
+VERSION = (0, 6, 27)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 21)
+VERSION = (0, 6, 22)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 19)
+VERSION = (0, 6, 20)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 25)
+VERSION = (0, 6, 26)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 23)
+VERSION = (0, 6, 24)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 20)
+VERSION = (0, 6, 21)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 7, 0)
+VERSION = (0, 7, 1)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -14,7 +14,7 @@ from .signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 27)
+VERSION = (0, 7, 0)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 22)
+VERSION = (0, 6, 23)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -1,13 +1,15 @@
-import document
-from document import *
-import fields
-from fields import *
-import connection
-from connection import *
-import queryset
-from queryset import *
-import signals
-from signals import *
+from __future__ import absolute_import
+
+from . import document
+from .document import *
+from . import fields
+from .fields import *
+from . import connection
+from .connection import *
+from . import queryset
+from .queryset import *
+from . import signals
+from .signals import *
 
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 18)
+VERSION = (0, 6, 19)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 14)
+VERSION = (0, 6, 15)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 16)
+VERSION = (0, 6, 17)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 17)
+VERSION = (0, 6, 18)
 
 
 def get_version():

--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -12,7 +12,7 @@ from signals import *
 __all__ = (document.__all__ + fields.__all__ + connection.__all__ +
            queryset.__all__ + signals.__all__)
 
-VERSION = (0, 6, 15)
+VERSION = (0, 6, 16)
 
 
 def get_version():

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -837,7 +837,7 @@ class BaseDocument(object):
                 self._mark_as_changed(name)
             return
 
-        if not self._created and name in self._meta.get('shard_key', tuple()):
+        if not self._created and name in self._meta.get('shard_key', tuple()) and self._data[name] != value:
             from queryset import OperationError
             raise OperationError(
                 "Shard Keys are immutable. Tried to update %s" % name)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -472,7 +472,7 @@ class ObjectIdField(BaseField):
     def to_mongo(self, value):
         if not isinstance(value, ObjectId):
             try:
-                return ObjectId(str(value))
+                return ObjectId(six.text_type(value))
             except Exception as e:
                 # e.message attribute has been deprecated since Python 2.6
                 self.error(six.text_type(e))
@@ -483,9 +483,9 @@ class ObjectIdField(BaseField):
 
     def validate(self, value):
         try:
-            ObjectId(str(value))
-        except:
-            self.error('Invalid Object ID')
+            ObjectId(six.text_type(value))
+        except Exception as e:
+            self.error(six.text_type(e))
 
 
 class DocumentMetaclass(type):

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1143,12 +1143,14 @@ class BaseDocument(object):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__) and hasattr(other, 'id'):
-            if self.id == other.id:
-                return True
-        return False
+            return self.id == other.id
+        return NotImplemented
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        res = self.__eq__(other)
+        if res == NotImplemented:
+            return NotImplemented
+        return not res
 
     def __hash__(self):
         if self.pk is None:

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -687,7 +687,7 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                     collection = base._get_collection_name()
                 # Propagate index options.
                 for key in ('index_background', 'index_drop_dups',
-                            'index_opts'):
+                            'index_opts', 'shard_key'):
                     if key in base._meta:
                         base_meta[key] = base._meta[key]
 

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -312,8 +312,8 @@ class ComplexBaseField(BaseField):
                 return value
 
         if self.field:
-            value_dict = dict([(key, self.field.to_python(item))
-                               for key, item in value.items()])
+            value_dict = {key: self.field.to_python(item)
+                          for key, item in value.items()}
         else:
             value_dict = {}
             for k, v in value.items():
@@ -336,13 +336,13 @@ class ComplexBaseField(BaseField):
         if not hasattr(value, 'items'):
             try:
                 is_list = True
-                value = dict([(k, v) for k, v in enumerate(value)])
+                value = {k: v for k, v in enumerate(value)}
             except TypeError:  # Not iterable return the value
                 return value
 
         if self.field:
-            value_dict = dict([(key, self.field.to_mongo(item))
-                               for key, item in value.items()])
+            value_dict = {key: self.field.to_mongo(item)
+                          for key, item in value.items()}
         else:
             value_dict = {}
             for k, v in value.items():
@@ -436,7 +436,7 @@ class BaseDynamicField(BaseField):
         is_list = False
         if not hasattr(value, 'items'):
             is_list = True
-            value = dict([(k, v) for k, v in enumerate(value)])
+            value = {k: v for k, v in enumerate(value)}
 
         data = {}
         for k, v in value.items():
@@ -495,8 +495,8 @@ class DocumentMetaclass(type):
     def __new__(cls, name, bases, attrs):
         def _get_mixin_fields(base):
             attrs = {}
-            attrs.update(dict([(k, v) for k, v in base.__dict__.items()
-                               if issubclass(v.__class__, BaseField)]))
+            attrs.update({k: v for k, v in base.__dict__.items()
+                          if issubclass(v.__class__, BaseField)})
 
             # Handle simple mixin's with meta
             if hasattr(base, 'meta') and \
@@ -586,11 +586,11 @@ class DocumentMetaclass(type):
                 "Multiple db_fields defined for: %s "
                 % ", ".join(duplicate_db_fields))
         attrs['_fields'] = doc_fields
-        attrs['_db_field_map'] = dict([
-            (k, v.db_field) for k, v in doc_fields.items()
-            if k != v.db_field])
-        attrs['_reverse_db_field_map'] = dict([
-            (v, k) for k, v in attrs['_db_field_map'].items()])
+        attrs['_db_field_map'] = {
+            k: v.db_field for k, v in doc_fields.items()
+            if k != v.db_field}
+        attrs['_reverse_db_field_map'] = {
+            v: k for k, v in attrs['_db_field_map'].items()}
 
         from .document import Document, EmbeddedDocument
         from .fields import DictField
@@ -860,7 +860,7 @@ class BaseDocument(object):
         is_list = False
         if not hasattr(value, 'items'):
             is_list = True
-            value = dict([(k, v) for k, v in enumerate(value)])
+            value = {k: v for k, v in enumerate(value)}
 
         if not is_list and '_cls' in value:
             cls = get_document(value['_cls'])
@@ -948,7 +948,7 @@ class BaseDocument(object):
         # get the class name from the document, falling back to the given
         # class if unavailable
         class_name = son.get(u'_cls', cls._class_name)
-        data = dict((str(key), value) for key, value in son.items())
+        data = {str(key): value for key, value in son.items()}
 
         if '_cls' in data:
             del data['_cls']

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -385,7 +385,7 @@ class ComplexBaseField(BaseField):
             for k, v in sequence:
                 try:
                     self.field.validate(v)
-                except (ValidationError, AssertionError), error:
+                except (ValidationError, AssertionError) as error:
                     if hasattr(error, 'errors'):
                         errors[k] = error.errors
                     else:
@@ -473,7 +473,7 @@ class ObjectIdField(BaseField):
         if not isinstance(value, ObjectId):
             try:
                 return ObjectId(str(value))
-            except Exception, e:
+            except Exception as e:
                 # e.message attribute has been deprecated since Python 2.6
                 self.error(six.text_type(e))
         return value
@@ -902,9 +902,9 @@ class BaseDocument(object):
             if value is not None:
                 try:
                     field._validate(value)
-                except ValidationError, error:
+                except ValidationError as error:
                     errors[field.name] = error.errors or error
-                except (ValueError, AttributeError, AssertionError), error:
+                except (ValueError, AttributeError, AssertionError) as error:
                     errors[field.name] = error
             elif field.required:
                 errors[field.name] = ValidationError('Field is required',

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -789,7 +789,7 @@ class BaseDocument(object):
         self._data = {}
 
         # Assign default values to instance
-        for attr_name, field in self._fields.items():
+        for attr_name in self._fields.keys():
             if attr_name not in values:
                 value = getattr(self, attr_name, None)
                 setattr(self, attr_name, value)

--- a/mongoengine/base.py
+++ b/mongoengine/base.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 from collections import defaultdict
 import warnings
 
-from queryset import QuerySet, QuerySetManager
-from queryset import DoesNotExist, MultipleObjectsReturned
-from queryset import DO_NOTHING
+from .queryset import QuerySet, QuerySetManager
+from .queryset import DoesNotExist, MultipleObjectsReturned
+from .queryset import DO_NOTHING
 
-from mongoengine import signals
+from . import signals
 
 import sys
 from bson import ObjectId
@@ -276,7 +278,7 @@ class ComplexBaseField(BaseField):
         instance._mark_as_changed(self.name)
 
     def _value_to_python(self, v):
-        from mongoengine import Document
+        from .document import Document
         if isinstance(v, Document):
             # We need the id from the saved object to create the DBRef
             if v.pk is None:
@@ -321,7 +323,7 @@ class ComplexBaseField(BaseField):
     def to_mongo(self, value):
         """Convert a Python type to a MongoDB-compatible type.
         """
-        from mongoengine import Document
+        from .document import Document
 
         if isinstance(value, basestring):
             return value
@@ -355,7 +357,7 @@ class ComplexBaseField(BaseField):
                     meta = getattr(v, 'meta', getattr(v, '_meta', {}))
                     if meta and not meta.get('allow_inheritance', True) and \
                             not self.field:
-                        from fields import GenericReferenceField
+                        from .fields import GenericReferenceField
                         value_dict[k] = GenericReferenceField().to_mongo(v)
                     else:
                         collection = v._get_collection_name()
@@ -586,7 +588,8 @@ class DocumentMetaclass(type):
         attrs['_reverse_db_field_map'] = dict([
             (v, k) for k, v in attrs['_db_field_map'].items()])
 
-        from mongoengine import Document, EmbeddedDocument, DictField
+        from .document import Document, EmbeddedDocument
+        from .fields import DictField
 
         new_class = super_new(cls, name, bases, attrs)
         for field in new_class._fields.values():
@@ -838,7 +841,7 @@ class BaseDocument(object):
             return
 
         if not self._created and name in self._meta.get('shard_key', tuple()) and self._data[name] != value:
-            from queryset import OperationError
+            from .queryset import OperationError
             raise OperationError(
                 "Shard Keys are immutable. Tried to update %s" % name)
 
@@ -981,7 +984,7 @@ class BaseDocument(object):
     def _get_changed_fields(self, key='', inspected=None):
         """Returns a list of all fields that have explicitly been changed.
         """
-        from mongoengine import EmbeddedDocument, DynamicEmbeddedDocument
+        from .document import EmbeddedDocument, DynamicEmbeddedDocument
         _changed_fields = []
         _changed_fields += getattr(self, '_changed_fields', [])
 

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -2,7 +2,7 @@ import pymongo
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
-from signals import pre_connect, post_connect
+import signals
 
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',
@@ -108,9 +108,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings.pop('read_preference')
 
         try:
-            pre_connect.send(alias, settings=conn_settings)
+            signals.pre_connect.send(alias, settings=conn_settings)
             _connections[alias] = MongoClient(**conn_settings)
-            post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
+            signals.post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
         except Exception, e:
             raise ConnectionError(
                 "Cannot connect to database %s :\n%s" % (alias, e))

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 import pymongo
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
-import signals
+from . import signals
 
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -32,8 +32,7 @@ def register_connection(alias, host='localhost', port=27017,
     :param name: the name of the specific database to use
     :param host: the host name of the :program:`mongod` instance to connect to
     :param port: the port that the :program:`mongod` instance is running on
-    :param is_slave: whether the connection can act as a slave ** Depreciated pymongo 2.0.1+
-    :param read_preference: The read preference for the collection ** Added pymongo 2.1
+    :param read_preference: The read preference for the collection
     :param slaves: a list of aliases of slave connections; each of these must
         be a registered connection that has :attr:`is_slave` set to ``True``
     :param username: username to authenticate with
@@ -109,7 +108,8 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
         try:
             _connections[alias] = MongoClient(**conn_settings)
         except Exception, e:
-            raise ConnectionError("Cannot connect to database %s :\n%s" % (alias, e))
+            raise ConnectionError(
+                "Cannot connect to database %s :\n%s" % (alias, e))
     return _connections[alias]
 
 
@@ -125,6 +125,7 @@ def register_db(
         'connection_alias': connection_alias,
         'db_name': db_name,
     }
+
 
 def get_db(alias=DEFAULT_DB_ALIAS, reconnect=False, refresh=False):
     global _dbs

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -106,8 +106,6 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings['slaves'] = slaves
                 conn_settings.pop('read_preference')
 
-        if 'replicaSet' in conn_settings:
-            conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
         try:
             _connections[alias] = MongoClient(**conn_settings)
         except Exception, e:

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pymongo
+import six
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
@@ -122,9 +123,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
 def register_db(
         db_name, db_alias=DEFAULT_DB_ALIAS,
         connection_alias=DEFAULT_CONNECTION_NAME):
-    assert isinstance(db_name, basestring)
-    assert isinstance(db_alias, basestring)
-    assert isinstance(connection_alias, basestring)
+    assert isinstance(db_name, six.string_types)
+    assert isinstance(db_alias, six.string_types)
+    assert isinstance(connection_alias, six.string_types)
 
     global _db_settings
     _db_settings[db_alias] = {

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -114,7 +114,7 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             signals.pre_connect.send(alias, settings=conn_settings)
             _connections[alias] = MongoClient(**conn_settings)
             signals.post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
-        except Exception, e:
+        except Exception as e:
             raise ConnectionError(
                 "Cannot connect to database %s :\n%s" % (alias, e))
     return _connections[alias]

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -2,6 +2,8 @@ import pymongo
 from pymongo import MongoClient, uri_parser
 from pymongo.read_preferences import ReadPreference
 
+from signals import pre_connect, post_connect
+
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',
            'DEFAULT_CONNECTION_NAME']
@@ -106,7 +108,9 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings.pop('read_preference')
 
         try:
+            pre_connect.send(alias, settings=conn_settings)
             _connections[alias] = MongoClient(**conn_settings)
+            post_connect.send(alias, settings=conn_settings, connection=_connections[alias])
         except Exception, e:
             raise ConnectionError(
                 "Cannot connect to database %s :\n%s" % (alias, e))

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,5 +1,6 @@
 import pymongo
-from pymongo import Connection, ReplicaSetConnection, uri_parser
+from pymongo import MongoClient, uri_parser
+from pymongo.read_preferences import ReadPreference
 
 
 __all__ = ['ConnectionError', 'connect', 'register_connection',
@@ -22,8 +23,8 @@ _db_settings = {}
 
 
 def register_connection(alias, host='localhost', port=27017,
-                        is_slave=False, read_preference=False, slaves=None,
-                        username=None, password=None, **kwargs):
+                        is_slave=False, read_preference=ReadPreference.PRIMARY,
+                        slaves=None, username=None, password=None, **kwargs):
     """Add a connection.
 
     :param alias: the name that will be used to refer to this connection
@@ -107,12 +108,10 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings['slaves'] = slaves
                 conn_settings.pop('read_preference')
 
-        connection_class = Connection
         if 'replicaSet' in conn_settings:
             conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
-            connection_class = ReplicaSetConnection
         try:
-            _connections[alias] = connection_class(**conn_settings)
+            _connections[alias] = MongoClient(**conn_settings)
         except Exception, e:
             raise ConnectionError("Cannot connect to database %s :\n%s" % (alias, e))
     return _connections[alias]

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -72,9 +72,7 @@ def disconnect(alias=DEFAULT_CONNECTION_NAME):
 
     if alias in _connections:
         conn = get_connection(alias=alias)
-        conn.disconnect()
-        if hasattr(conn, 'close'):
-            conn.close()
+        conn.close()
         del _connections[alias]
     if alias in _dbs:
         del _dbs[alias]

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -25,7 +25,8 @@ class DeReference(object):
             :class:`~mongoengine.base.ComplexBaseField`
         :param get: A boolean determining if being called by __get__
         """
-        if items is None or isinstance(items, basestring):
+        if items is None or isinstance(
+                items, six.string_types + (six.binary_type,)):
             return items
 
         # cheapest way to convert a queryset to a list

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+
 from bson import DBRef, SON
 
-from base import (BaseDict, BaseList, TopLevelDocumentMetaclass, get_document)
-from fields import (ReferenceField, ListField, DictField, MapField)
-from connection import get_db
-from queryset import QuerySet
-from document import Document
+from .base import (BaseDict, BaseList, TopLevelDocumentMetaclass, get_document)
+from .fields import (ReferenceField, ListField, DictField, MapField)
+from .connection import get_db
+from .queryset import QuerySet
+from .document import Document
 
 
 class DeReference(object):

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -107,9 +107,8 @@ class DeReference(object):
         """
         object_map = {}
         for col, dbrefs in six.iteritems(self.reference_map):
-            keys = object_map.keys()
-            refs = list(set(
-                [dbref for dbref in dbrefs if str(dbref) not in keys]))
+            keys = set(object_map.keys())
+            refs = list({dbref for dbref in dbrefs if str(dbref) not in keys})
             if hasattr(col, 'objects'):  # We have a document class for the refs
                 references = col.objects.in_bulk(refs)
                 for key, doc in six.iteritems(references):

--- a/mongoengine/dereference.py
+++ b/mongoengine/dereference.py
@@ -115,7 +115,7 @@ class DeReference(object):
                     object_map[key] = doc
             else:  # Generic reference: use the refs data to convert to document
                 if doc_type and \
-                        not isinstance(doc_type, (ListField, DictField, MapField,)):  # noqa
+                        not isinstance(doc_type, (ListField, DictField, MapField)):  # noqa
                     references = doc_type._get_db()[col].find(
                         {'_id': {'$in': refs}})
                     for ref in references:

--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -1,4 +1,6 @@
-from mongoengine import *
+from __future__ import absolute_import
+
+from .. import *
 
 from django.utils.hashcompat import md5_constructor, sha_constructor
 from django.utils.encoding import smart_str

--- a/mongoengine/django/auth.py
+++ b/mongoengine/django/auth.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .. import *
 
+import six
 from django.utils.hashcompat import md5_constructor, sha_constructor
 from django.utils.encoding import smart_str
 from django.contrib.auth.models import AnonymousUser
@@ -20,6 +21,7 @@ def get_hexdigest(algorithm, salt, raw_password):
     raise ValueError('Got unknown password algorithm type in password')
 
 
+@six.python_2_unicode_compatible
 class User(Document):
     """A User document that aims to mirror most of the API specified by Django
     at http://docs.djangoproject.com/en/dev/topics/auth/#users
@@ -57,7 +59,7 @@ class User(Document):
         ]
     }
 
-    def __unicode__(self):
+    def __str__(self):
         return self.username
 
     def get_full_name(self):

--- a/mongoengine/django/sessions.py
+++ b/mongoengine/django/sessions.py
@@ -19,7 +19,7 @@ class MongoSession(Document):
     session_key = fields.StringField(primary_key=True, max_length=40)
     session_data = fields.StringField()
     expire_date = fields.DateTimeField()
-    
+
     meta = {'collection': 'django_session',
             'db_alias': MONGOENGINE_SESSION_DB_ALIAS,
             'allow_inheritance': False}

--- a/mongoengine/django/sessions.py
+++ b/mongoengine/django/sessions.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 from django.contrib.sessions.backends.base import SessionBase, CreateError
 from django.core.exceptions import SuspiciousOperation
 from django.utils.encoding import force_unicode
 
-from mongoengine.document import Document
-from mongoengine import fields
-from mongoengine.queryset import OperationError
-from mongoengine.connection import DEFAULT_CONNECTION_NAME
+from ..document import Document
+from .. import fields
+from ..queryset import OperationError
+from ..connection import DEFAULT_CONNECTION_NAME
 from django.conf import settings
 from datetime import datetime
 

--- a/mongoengine/django/shortcuts.py
+++ b/mongoengine/django/shortcuts.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
 from django.http import Http404
-from mongoengine.queryset import QuerySet
-from mongoengine.base import BaseDocument
-from mongoengine.base import ValidationError
+from ..queryset import QuerySet
+from ..base import BaseDocument
+from ..base import ValidationError
 
 def _get_queryset(cls):
     """Inspired by django.shortcuts.*"""

--- a/mongoengine/django/storage.py
+++ b/mongoengine/django/storage.py
@@ -102,7 +102,7 @@ class GridFSStorage(Storage):
         count = itertools.count(1)
         while self.exists(name):
             # file_ext includes the dot.
-            name = os.path.join("%s_%s%s" % (file_root, count.next(), file_ext))
+            name = os.path.join("%s_%s%s" % (file_root, next(count), file_ext))
 
         return name
 

--- a/mongoengine/django/storage.py
+++ b/mongoengine/django/storage.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 import itertools
-import urlparse
+from six.moves import urllib
 
 from .. import *
 from django.conf import settings
@@ -72,7 +72,7 @@ class GridFSStorage(Storage):
         """
         if self.base_url is None:
             raise ValueError("This file is not accessible via a URL.")
-        return urlparse.urljoin(self.base_url, name).replace('\\', '/')
+        return urllib.parse.urljoin(self.base_url, name).replace('\\', '/')
 
     def _get_doc_with_name(self, name):
         """Find the documents in the store with the given name

--- a/mongoengine/django/storage.py
+++ b/mongoengine/django/storage.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+
 import os
 import itertools
 import urlparse
 
-from mongoengine import *
+from .. import *
 from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.exceptions import ImproperlyConfigured

--- a/mongoengine/django/tests.py
+++ b/mongoengine/django/tests.py
@@ -1,4 +1,6 @@
 #coding: utf-8
+from __future__ import absolute_import
+
 from django.test import TestCase
 from django.conf import settings
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pymongo
+import six
 from bson.dbref import DBRef
 
 from . import signals
@@ -235,9 +236,9 @@ class Document(BaseDocument):
 
         except pymongo.errors.OperationFailure, err:
             message = 'Could not save document (%s)'
-            if u'duplicate key' in unicode(err):
+            if u'duplicate key' in six.text_type(err):
                 message = u'Tried to save duplicate unique keys (%s)'
-            raise OperationError(message % unicode(err))
+            raise OperationError(message % six.text_type(err))
         id_field = self._meta['id_field']
         self[id_field] = self._fields[id_field].to_python(object_id)
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -8,7 +8,8 @@ from queryset import OperationError
 from connection import get_db, DEFAULT_CONNECTION_NAME
 
 __all__ = ['Document', 'EmbeddedDocument', 'DynamicDocument',
-           'DynamicEmbeddedDocument', 'OperationError', 'InvalidCollectionError']
+           'DynamicEmbeddedDocument', 'OperationError',
+           'InvalidCollectionError']
 
 
 class InvalidCollectionError(Exception):
@@ -81,6 +82,7 @@ class Document(BaseDocument):
         """
         def fget(self):
             return getattr(self, self._meta['id_field'])
+
         def fset(self, value):
             return setattr(self, self._meta['id_field'], value)
         return property(fget, fset)
@@ -88,7 +90,7 @@ class Document(BaseDocument):
     @classmethod
     def _get_db(cls):
         """Some Model using other db_alias"""
-        return get_db(cls._meta.get("db_alias", DEFAULT_CONNECTION_NAME ))
+        return get_db(cls._meta.get("db_alias", DEFAULT_CONNECTION_NAME))
 
     @classmethod
     def _get_subdocuments(cls):
@@ -122,7 +124,8 @@ class Document(BaseDocument):
                     if options.get('max') != max_documents or \
                        options.get('size') != max_size:
                         msg = ('Cannot create collection "%s" as a capped '
-                               'collection as it already exists') % cls._collection
+                               'collection as it already exists'
+                               % cls._collection)
                         raise InvalidCollectionError(msg)
                 else:
                     # Create the collection as a capped collection
@@ -139,7 +142,7 @@ class Document(BaseDocument):
         return cls._collection
 
     def save(self, force_insert=False, validate=True, write_options=None,
-            cascade=None, cascade_kwargs=None, _refs=None):
+             cascade=None, cascade_kwargs=None, _refs=None):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
         created.
@@ -150,12 +153,15 @@ class Document(BaseDocument):
         :param write_options: Extra keyword arguments are passed down to
                 :meth:`~pymongo.collection.Collection.save` OR
                 :meth:`~pymongo.collection.Collection.insert`
-                which will be used as options for the resultant ``getLastError`` command.
-                For example, ``save(..., w=2, fsync=True)`` will wait until at least two servers
-                have recorded the write and will force an fsync on each server being written to.
-        :param cascade: Sets the flag for cascading saves.  You can set a default by setting
-            "cascade" in the document __meta__
-        :param cascade_kwargs: optional kwargs dictionary to be passed throw to cascading saves
+                which will be used as options for the resultant
+                ``getLastError`` command.
+                For example, ``save(..., w=2, fsync=True)`` will wait until at
+                least two servers have recorded the write and will force an
+                fsync on each server being written to.
+        :param cascade: Sets the flag for cascading saves.  You can set a
+            default by setting "cascade" in the document __meta__
+        :param cascade_kwargs: optional kwargs dictionary to be passed throw
+            to cascading saves
         :param _refs: A list of processed references used in cascading saves
 
         .. versionchanged:: 0.5
@@ -163,11 +169,12 @@ class Document(BaseDocument):
             Saves are cascaded and any :class:`~bson.dbref.DBRef` objects
             that have changes are saved as well.
         .. versionchanged:: 0.6
-            Cascade saves are optional = defaults to True, if you want fine grain
-            control then you can turn off using document meta['cascade'] = False
-            Also you can pass different kwargs to the cascade save using cascade_kwargs
-            which overwrites the existing kwargs with custom values
-
+            Cascade saves are optional = defaults to True, if you want fine
+            grain control then you can turn off using document
+            meta['cascade'] = False
+            Also you can pass different kwargs to the cascade save using
+            cascade_kwargs which overwrites the existing kwargs with custom
+            values
         """
         signals.pre_save.send(self.__class__, document=self)
 
@@ -201,11 +208,17 @@ class Document(BaseDocument):
 
                 upsert = self._created
                 if updates:
-                    collection.update(select_dict, {"$set": updates}, upsert=upsert, **write_options)
+                    collection.update(select_dict,
+                                      {"$set": updates},
+                                      upsert=upsert,
+                                      **write_options)
                 if removals:
-                    collection.update(select_dict, {"$unset": removals}, upsert=upsert, **write_options)
+                    collection.update(select_dict,
+                                      {"$unset": removals},
+                                      upsert=upsert,
+                                      **write_options)
 
-            cascade = self._meta.get('cascade', True) if cascade is None else cascade
+            cascade = self._meta.get('cascade', True) if cascade is None else cascade  # noqa
             if cascade:
                 kwargs = {
                     "force_insert": force_insert,
@@ -419,8 +432,8 @@ class MapReduceDocument(object):
             try:
                 self.key = id_field_type(self.key)
             except:
-                raise Exception("Could not cast key as %s" % \
-                                id_field_type.__name__)
+                raise Exception(
+                    "Could not cast key as %s" % id_field_type.__name__)
 
         if not hasattr(self, "_key_object"):
             self._key_object = self._document.objects.with_id(self.key)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -328,6 +328,9 @@ class Document(BaseDocument):
         .. versionchanged:: 0.6  Now chainable
         """
         obj = self.__class__.objects(**self._object_key).first()
+        if obj is None:
+            raise self.DoesNotExist('Document does not exist')
+
         for field in self._fields:
             setattr(self, field, self._reload(field, obj[field]))
         if self._dynamic:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -78,16 +78,15 @@ class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
     """
     _base = True
 
-    @apply
-    def pk():
+    @property
+    def pk(self):
         """Primary key alias
         """
-        def fget(self):
-            return getattr(self, self._meta['id_field'])
+        return getattr(self, self._meta['id_field'])
 
-        def fset(self, value):
-            return setattr(self, self._meta['id_field'], value)
-        return property(fget, fset)
+    @pk.setter
+    def pk(self, value):
+        return setattr(self, self._meta['id_field'], value)
 
     @classmethod
     def _get_db(cls):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import
+
 import pymongo
 from bson.dbref import DBRef
 
-from mongoengine import signals
-from base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
+from . import signals
+from .base import (DocumentMetaclass, TopLevelDocumentMetaclass, BaseDocument,
                   BaseDict, BaseList)
-from queryset import OperationError, QuerySet
-from connection import get_db, DEFAULT_CONNECTION_NAME
+from .queryset import OperationError, QuerySet
+from .connection import get_db, DEFAULT_CONNECTION_NAME
 
 __all__ = ['Document', 'EmbeddedDocument', 'DynamicDocument',
            'DynamicEmbeddedDocument', 'OperationError',
@@ -245,7 +247,7 @@ class Document(BaseDocument):
 
     def cascade_save(self, *args, **kwargs):
         """Recursively saves any references / generic references on an object"""
-        from fields import ReferenceField, GenericReferenceField
+        from .fields import ReferenceField, GenericReferenceField
         _refs = kwargs.get('_refs', []) or []
         for name, cls in self._fields.items():
             if not isinstance(cls, (ReferenceField, GenericReferenceField)):
@@ -317,7 +319,7 @@ class Document(BaseDocument):
 
         .. versionadded:: 0.5
         """
-        from dereference import DeReference
+        from .dereference import DeReference
         self._data = DeReference()(self._data, max_depth)
         return self
 
@@ -373,7 +375,7 @@ class Document(BaseDocument):
         """Drops the entire collection associated with this
         :class:`~mongoengine.Document` type from the database.
         """
-        from mongoengine.queryset import QuerySet
+        from .queryset import QuerySet
         db = cls._get_db()
         db.drop_collection(cls._get_collection_name())
         QuerySet._reset_already_indexed(cls)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -313,10 +313,7 @@ class Document(BaseDocument):
         .. versionadded:: 0.1.2
         .. versionchanged:: 0.6  Now chainable
         """
-        id_field = self._meta['id_field']
-        obj = self.__class__.objects(
-            **{id_field: self[id_field]}
-        ).first()
+        obj = self.__class__.objects(**self._object_key).first()
         for field in self._fields:
             setattr(self, field, self._reload(field, obj[field]))
         if self._dynamic:

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -267,7 +267,10 @@ class Document(BaseDocument):
         select_dict = {'pk': self.pk}
         shard_key = self.__class__._meta.get('shard_key', tuple())
         for k in shard_key:
-            select_dict[k] = getattr(self, k)
+            if k == '_id':
+                select_dict['id'] = getattr(self, 'id')
+            else:
+                select_dict[k] = getattr(self, k)
         return select_dict
 
     def update(self, **kwargs):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -19,14 +19,13 @@ class InvalidCollectionError(Exception):
     pass
 
 
-class EmbeddedDocument(BaseDocument):
+class EmbeddedDocument(six.with_metaclass(DocumentMetaclass, BaseDocument)):
     """A :class:`~mongoengine.Document` that isn't stored in its own
     collection.  :class:`~mongoengine.EmbeddedDocument`\ s should be used as
     fields on :class:`~mongoengine.Document`\ s through the
     :class:`~mongoengine.EmbeddedDocumentField` field type.
     """
-
-    __metaclass__ = DocumentMetaclass
+    _base = True
 
     def __init__(self, *args, **kwargs):
         super(EmbeddedDocument, self).__init__(*args, **kwargs)
@@ -44,7 +43,7 @@ class EmbeddedDocument(BaseDocument):
             super(EmbeddedDocument, self).__delattr__(*args, **kwargs)
 
 
-class Document(BaseDocument):
+class Document(six.with_metaclass(TopLevelDocumentMetaclass, BaseDocument)):
     """The base class used for defining the structure and properties of
     collections of documents stored in MongoDB. Inherit from this class, and
     add fields as class attributes to define a document's structure.
@@ -77,7 +76,7 @@ class Document(BaseDocument):
     names. Index direction may be specified by prefixing the field names with
     a **+** or **-** sign.
     """
-    __metaclass__ = TopLevelDocumentMetaclass
+    _base = True
 
     @apply
     def pk():
@@ -382,7 +381,7 @@ class Document(BaseDocument):
         QuerySet._reset_already_indexed(cls)
 
 
-class DynamicDocument(Document):
+class DynamicDocument(six.with_metaclass(TopLevelDocumentMetaclass, Document)):
     """A Dynamic Document class allowing flexible, expandable and uncontrolled
     schemas.  As a :class:`~mongoengine.Document` subclass, acts in the same
     way as an ordinary document but has expando style properties.  Any data
@@ -395,7 +394,7 @@ class DynamicDocument(Document):
 
         There is one caveat on Dynamic Documents: fields cannot start with `_`
     """
-    __metaclass__ = TopLevelDocumentMetaclass
+    _base = True
     _dynamic = True
 
     def __delattr__(self, *args, **kwargs):
@@ -408,13 +407,12 @@ class DynamicDocument(Document):
             super(DynamicDocument, self).__delattr__(*args, **kwargs)
 
 
-class DynamicEmbeddedDocument(EmbeddedDocument):
+class DynamicEmbeddedDocument(six.with_metaclass(DocumentMetaclass, EmbeddedDocument)):
     """A Dynamic Embedded Document class allowing flexible, expandable and
     uncontrolled schemas. See :class:`~mongoengine.DynamicDocument` for more
     information about dynamic documents.
     """
-
-    __metaclass__ = DocumentMetaclass
+    _base = True
     _dynamic = True
 
     def __delattr__(self, *args, **kwargs):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -260,6 +260,16 @@ class Document(BaseDocument):
                 ref.save(**kwargs)
                 ref._changed_fields = []
 
+    @property
+    def _object_key(self):
+        """Dict to identify object in collection
+        """
+        select_dict = {'pk': self.pk}
+        shard_key = self.__class__._meta.get('shard_key', tuple())
+        for k in shard_key:
+            select_dict[k] = getattr(self, k)
+        return select_dict
+
     def update(self, **kwargs):
         """Performs an update on the :class:`~mongoengine.Document`
         A convenience wrapper to :meth:`~mongoengine.QuerySet.update`.
@@ -271,11 +281,7 @@ class Document(BaseDocument):
             raise OperationError('attempt to update a document not yet saved')
 
         # Need to add shard key to query, or you get an error
-        select_dict = {'pk': self.pk}
-        shard_key = self.__class__._meta.get('shard_key', tuple())
-        for k in shard_key:
-            select_dict[k] = getattr(self, k)
-        return self.__class__.objects(**select_dict).update_one(**kwargs)
+        return self.__class__.objects(**self._object_key).update_one(**kwargs)
 
     def delete(self, w=1):
         """Delete the :class:`~mongoengine.Document` from the database. This
@@ -284,7 +290,7 @@ class Document(BaseDocument):
         signals.pre_delete.send(self.__class__, document=self)
 
         try:
-            self.__class__.objects(pk=self.pk).delete(w=w)
+            self.__class__.objects(**self._object_key).delete(w=w)
         except pymongo.errors.OperationFailure, err:
             message = u'Could not delete document (%s)' % err.message
             raise OperationError(message)

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -234,7 +234,7 @@ class Document(BaseDocument):
                 kwargs['_refs'] = _refs
                 self.cascade_save(**kwargs)
 
-        except pymongo.errors.OperationFailure, err:
+        except pymongo.errors.OperationFailure as err:
             message = 'Could not save document (%s)'
             if u'duplicate key' in six.text_type(err):
                 message = u'Tried to save duplicate unique keys (%s)'
@@ -308,7 +308,7 @@ class Document(BaseDocument):
         try:
             self._qs.filter(**self._object_key).delete(
                 w=w, _from_doc_delete=True)
-        except pymongo.errors.OperationFailure, err:
+        except pymongo.errors.OperationFailure as err:
             message = u'Could not delete document (%s)' % err.message
             raise OperationError(message)
 

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -138,16 +138,12 @@ class Document(BaseDocument):
                 cls._collection = db[collection_name]
         return cls._collection
 
-    def save(self, safe=True, force_insert=False, validate=True, write_options=None,
+    def save(self, force_insert=False, validate=True, write_options=None,
             cascade=None, cascade_kwargs=None, _refs=None):
         """Save the :class:`~mongoengine.Document` to the database. If the
         document already exists, it will be updated, otherwise it will be
         created.
 
-        If ``safe=True`` and the operation is unsuccessful, an
-        :class:`~mongoengine.OperationError` will be raised.
-
-        :param safe: check if the operation succeeded before returning
         :param force_insert: only try to create a new document, don't allow
             updates of existing documents
         :param validate: validates the document; set to ``False`` to skip.
@@ -179,7 +175,7 @@ class Document(BaseDocument):
             self.validate()
 
         if not write_options:
-            write_options = {}
+            write_options = {"w": 1}
 
         doc = self.to_mongo()
 
@@ -189,9 +185,9 @@ class Document(BaseDocument):
             collection = self.__class__.objects._collection
             if created:
                 if force_insert:
-                    object_id = collection.insert(doc, safe=safe, **write_options)
+                    object_id = collection.insert(doc, **write_options)
                 else:
-                    object_id = collection.save(doc, safe=safe, **write_options)
+                    object_id = collection.save(doc, **write_options)
             else:
                 object_id = doc['_id']
                 updates, removals = self._delta()
@@ -205,14 +201,13 @@ class Document(BaseDocument):
 
                 upsert = self._created
                 if updates:
-                    collection.update(select_dict, {"$set": updates}, upsert=upsert, safe=safe, **write_options)
+                    collection.update(select_dict, {"$set": updates}, upsert=upsert, **write_options)
                 if removals:
-                    collection.update(select_dict, {"$unset": removals}, upsert=upsert, safe=safe, **write_options)
+                    collection.update(select_dict, {"$unset": removals}, upsert=upsert, **write_options)
 
             cascade = self._meta.get('cascade', True) if cascade is None else cascade
             if cascade:
                 kwargs = {
-                    "safe": safe,
                     "force_insert": force_insert,
                     "validate": validate,
                     "write_options": write_options,
@@ -269,16 +264,14 @@ class Document(BaseDocument):
             select_dict[k] = getattr(self, k)
         return self.__class__.objects(**select_dict).update_one(**kwargs)
 
-    def delete(self, safe=False):
+    def delete(self, w=1):
         """Delete the :class:`~mongoengine.Document` from the database. This
         will only take effect if the document has been previously saved.
-
-        :param safe: check if the operation succeeded before returning
         """
         signals.pre_delete.send(self.__class__, document=self)
 
         try:
-            self.__class__.objects(pk=self.pk).delete(safe=safe)
+            self.__class__.objects(pk=self.pk).delete(w=w)
         except pymongo.errors.OperationFailure, err:
             message = u'Could not delete document (%s)' % err.message
             raise OperationError(message)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1123,7 +1123,7 @@ class ImageField(FileField):
         for att_name, att in extra_args.items():
             if att and (isinstance(att, tuple) or isinstance(att, list)):
                 setattr(self, att_name, dict(
-                        map(None, params_size, att)))
+                        six.moves.zip_longest(params_size, att)))
             else:
                 setattr(self, att_name, None)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -931,8 +931,8 @@ class FileField(BaseField):
 
     def __set__(self, instance, value):
         key = self.name
-        if isinstance(value, file) or isinstance(
-                value, six.string_types + (six.binary_type,)):
+        is_file = hasattr(value, 'read') and not isinstance(value, GridFSProxy)
+        if is_file or isinstance(value, six.string_types + (six.binary_type,)):
             # using "FileField() = file/string" notation
             grid_file = instance._data.get(self.name)
             # If a file already exists, delete it

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import datetime
 import time
 import decimal
@@ -5,13 +7,14 @@ import gridfs
 import re
 import uuid
 
+import six
 from bson import Binary, DBRef, SON, ObjectId
 
-from base import (BaseField, ComplexBaseField, ObjectIdField,
+from .base import (BaseField, ComplexBaseField, ObjectIdField,
                   ValidationError, get_document)
-from queryset import DO_NOTHING, QuerySet
-from document import Document, EmbeddedDocument
-from connection import get_db, DEFAULT_CONNECTION_NAME
+from .queryset import DO_NOTHING, QuerySet
+from .document import Document, EmbeddedDocument
+from .connection import get_db, DEFAULT_CONNECTION_NAME
 from operator import itemgetter
 
 
@@ -20,11 +23,6 @@ try:
 except ImportError:
     Image = None
     ImageOps = None
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
 
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'BooleanField',
@@ -1028,7 +1026,7 @@ class ImageGridFsProxy(GridFSProxy):
 
         w, h = img.size
 
-        io = StringIO()
+        io = six.BytesIO()
         img.save(io, img.format)
         io.seek(0)
 
@@ -1050,7 +1048,7 @@ class ImageGridFsProxy(GridFSProxy):
     def _put_thumbnail(self, thumbnail, format, **kwargs):
         w, h = thumbnail.size
 
-        io = StringIO()
+        io = six.BytesIO()
         thumbnail.save(io, format)
         io.seek(0)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -354,7 +354,7 @@ class ComplexDateTimeField(StringField):
         datetime.datetime(2011, 6, 8, 20, 26, 24, 192284)
         """
         data = data.split(',')
-        data = map(int, data)
+        data = list(map(int, data))
         values = {}
         for i in range(7):
             values[self.names[i]] = data[i]
@@ -518,9 +518,9 @@ class SortedListField(ListField):
     _order_reverse = False
 
     def __init__(self, field, **kwargs):
-        if 'ordering' in kwargs.keys():
+        if 'ordering' in kwargs:
             self._ordering = kwargs.pop('ordering')
-        if 'reverse' in kwargs.keys():
+        if 'reverse' in kwargs:
             self._order_reverse = kwargs.pop('reverse')
         super(SortedListField, self).__init__(field, **kwargs)
 

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -814,8 +814,10 @@ class GridFSProxy(object):
     def __get__(self, instance, value):
         return self
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.grid_id)
+
+    __nonzero__ = __bool__
 
     def __getstate__(self):
         self_dict = self.__dict__

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -117,7 +117,7 @@ class URLField(StringField):
             try:
                 request = urllib2.Request(value)
                 urllib2.urlopen(request)
-            except Exception, e:
+            except Exception as e:
                 self.error('This URL appears to be a broken link: %s' % e)
 
 
@@ -216,7 +216,7 @@ class DecimalField(BaseField):
                 value = six.text_type(value)
             try:
                 value = decimal.Decimal(value)
-            except Exception, exc:
+            except Exception as exc:
                 self.error('Could not convert value to decimal: %s' % exc)
 
         if self.min_value is not None and value < self.min_value:
@@ -1237,5 +1237,5 @@ class UUIDField(BaseField):
                 value = six.text_type(value)
             try:
                 value = uuid.UUID(value)
-            except Exception, exc:
+            except Exception as exc:
                 self.error('Could not convert to UUID: %s' % exc)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -113,10 +113,9 @@ class URLField(StringField):
             self.error('Invalid URL: %s' % value)
 
         if self.verify_exists:
-            import urllib2
             try:
-                request = urllib2.Request(value)
-                urllib2.urlopen(request)
+                request = six.moves.urllib.request.Request(value)
+                six.moves.urllib.request.urlopen(request)
             except Exception as e:
                 self.error('This URL appears to be a broken link: %s' % e)
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -319,8 +319,10 @@ class QueryFieldList(object):
         self.fields = set([])
         self.value = self.ONLY
 
-    def __nonzero__(self):
+    def __bool__(self):
         return bool(self.fields)
+
+    __nonzero__ = __bool__
 
 
 class QuerySet(six.Iterator):

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -351,6 +351,7 @@ class QuerySet(object):
         self._limit = None
         self._skip = None
         self._hint = -1  # Using -1 as None is a valid value for hint
+        self._batch_size = None
 
     def clone(self):
         """Creates a copy of the current :class:`~mongoengine.queryset.QuerySet`
@@ -361,7 +362,7 @@ class QuerySet(object):
 
         copy_props = ('_initial_query', '_query_obj', '_where_clause',
                     '_loaded_fields', '_ordering',
-                    '_limit', '_skip',  '_hint',
+                    '_limit', '_skip',  '_hint', '_batch_size',
                     '_read_preference',)
 
         for prop in copy_props:
@@ -521,6 +522,9 @@ class QuerySet(object):
 
             if self._hint != -1:
                 self._cursor_obj.hint(self._hint)
+
+            if self._batch_size is not None:
+                self._cursor_obj.batch_size(self._batch_size)
 
         return self._cursor_obj
 
@@ -1012,6 +1016,21 @@ class QuerySet(object):
             self._cursor_obj.hint(index)
 
         self._hint = index
+        return self
+
+    def batch_size(self, size):
+        """Limit the number of documents returned in a single batch (each batch
+        requires a round trip to the server).
+
+
+        See http://api.mongodb.com/python/current/api/pymongo/cursor.html#pymongo.cursor.Cursor.batch_size
+        for details.
+        :param size: desired size of each batch.
+        """
+        if self._cursor_obj is not None:
+            self._cursor_obj.batch_size(size)
+
+        self._batch_size = size
         return self
 
     def __getitem__(self, key):

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -547,7 +547,7 @@ class QuerySet(six.Iterator):
             if field_name.isdigit():
                 try:
                     new_field = field.field
-                except AttributeError, err:
+                except AttributeError as err:
                     raise InvalidQueryError(
                         "Can't use index on unsubscriptable field (%s)" % err)
                 fields.append(field_name)
@@ -1057,7 +1057,7 @@ class QuerySet(six.Iterator):
                 self._skip, self._limit = key.start, key.stop
                 if key.start and key.stop:
                     self._limit = key.stop - key.start
-            except IndexError, err:
+            except IndexError as err:
                 # PyMongo raises an error if key.start == key.stop, catch it,
                 # bin it, kill it.
                 start = key.start or 0
@@ -1355,7 +1355,7 @@ class QuerySet(six.Iterator):
                                           **write_options)
             if ret is not None and 'n' in ret:
                 return ret['n']
-        except pymongo.errors.OperationFailure, err:
+        except pymongo.errors.OperationFailure as err:
             if six.text_type(err) == u'multi not coded yet':
                 message = u'update() method requires MongoDB 1.1.3+'
                 raise OperationError(message)
@@ -1387,7 +1387,7 @@ class QuerySet(six.Iterator):
 
             if ret is not None and 'n' in ret:
                 return ret['n']
-        except pymongo.errors.OperationFailure, e:
+        except pymongo.errors.OperationFailure as e:
             raise OperationError(u'Update failed [%s]' % six.text_type(e))
 
     def __iter__(self):

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1022,6 +1022,8 @@ class QuerySet(object):
             try:
                 self._cursor_obj = self._cursor[key]
                 self._skip, self._limit = key.start, key.stop
+                if key.start and key.stop:
+                    self._limit = key.stop - key.start
             except IndexError, err:
                 # PyMongo raises an error if key.start == key.stop, catch it,
                 # bin it, kill it.
@@ -1665,10 +1667,10 @@ class QuerySet(object):
         if self._limit is None:
             stop = start + limit
         if self._limit is not None:
-            if self._limit - start > limit:
+            if self._limit > limit:
                 stop = start + limit
             else:
-                stop = self._limit
+                stop = start + self._limit
         try:
             data = list(self[start:stop])
         except pymongo.errors.InvalidOperation:

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1768,7 +1768,7 @@ class QuerySetManager(object):
         queryset_class = owner._meta['queryset_class'] or QuerySet
         queryset = queryset_class(owner, owner._get_collection())
         if self.get_queryset:
-            if self.get_queryset.func_code.co_argcount == 1:
+            if six.get_function_code(self.get_queryset).co_argcount == 1:
                 queryset = self.get_queryset(queryset)
             else:
                 queryset = self.get_queryset(owner, queryset)
@@ -1783,7 +1783,7 @@ def queryset_manager(func):
     function should return a :class:`~mongoengine.queryset.QuerySet`, probably
     the same one that was passed in, but modified in some way.
     """
-    if func.func_code.co_argcount == 1:
+    if six.get_function_code(func).co_argcount == 1:
         import warnings
         msg = 'Methods decorated with queryset_manager should take 2 arguments'
         warnings.warn(msg, DeprecationWarning)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -972,6 +972,12 @@ class QuerySet(object):
 
         :param n: the maximum number of objects to return
         """
+        if self._cursor_obj is not None:
+            if n == 0:
+                self._cursor_obj.limit(1)
+            else:
+                self._cursor_obj.limit(n)
+
         self._limit = n
 
         # Return self to allow chaining
@@ -983,6 +989,9 @@ class QuerySet(object):
 
         :param n: the number of objects to skip before returning results
         """
+        if self._cursor_obj is not None and n:
+            self._cursor_obj.skip(n)
+
         self._skip = n
         return self
 
@@ -999,6 +1008,9 @@ class QuerySet(object):
 
         .. versionadded:: 0.5
         """
+        if self._cursor_obj is not None:
+            self._cursor_obj.hint(index)
+
         self._hint = index
         return self
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1655,7 +1655,7 @@ class QuerySet(six.Iterator):
 
         if normalize:
             count = sum(frequencies.values())
-            frequencies = dict([(k, v / count) for k, v in frequencies.items()])
+            frequencies = {k: v / count for k, v in frequencies.items()}
 
         return frequencies
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import pprint
 import re
 import copy
@@ -7,7 +9,7 @@ import operator
 import pymongo
 from bson.code import Code
 
-from mongoengine import signals
+from . import signals
 
 __all__ = ['queryset_manager', 'Q', 'InvalidQueryError',
            'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']
@@ -557,19 +559,19 @@ class QuerySet(object):
                 if field_name in document._fields:
                     field = document._fields[field_name]
                 elif document._dynamic:
-                    from base import BaseDynamicField
+                    from .base import BaseDynamicField
                     field = BaseDynamicField(db_field=field_name)
                 else:
                     raise InvalidQueryError('Cannot resolve field "%s"'
                                             % field_name)
             else:
-                from mongoengine.fields import ReferenceField, GenericReferenceField  # noqa
+                from .fields import ReferenceField, GenericReferenceField  # noqa
                 if isinstance(field, (ReferenceField, GenericReferenceField)):
                     raise InvalidQueryError('Cannot perform join in mongoDB: %s'
                                             % '__'.join(parts))
                 # Look up subfield on the previous field
                 new_field = field.lookup_member(field_name)
-                from base import ComplexBaseField
+                from .base import ComplexBaseField
                 if not new_field and isinstance(field, ComplexBaseField):
                     fields.append(field_name)
                     continue
@@ -646,7 +648,7 @@ class QuerySet(object):
                     if isinstance(field, basestring):
                         if op in match_operators and isinstance(value,
                                                                 basestring):
-                            from mongoengine import StringField
+                            from . import StringField
                             value = StringField.prepare_query_value(op, value)
                         else:
                             value = field
@@ -788,7 +790,7 @@ class QuerySet(object):
 
         .. versionadded:: 0.5
         """
-        from document import Document
+        from .document import Document
 
         docs = doc_or_docs
         return_one = False
@@ -928,7 +930,7 @@ class QuerySet(object):
 
         .. versionadded:: 0.3
         """
-        from document import MapReduceDocument
+        from .document import MapReduceDocument
 
         if not hasattr(self._collection, "map_reduce"):
             raise NotImplementedError("Requires MongoDB >= 1.7.1")
@@ -1083,7 +1085,7 @@ class QuerySet(object):
         .. versionadded:: 0.4
         .. versionchanged:: 0.5 - Fixed handling references
         """
-        from dereference import DeReference
+        from .dereference import DeReference
         return DeReference()(self._cursor.distinct(field), 1)
 
     def only(self, *fields):
@@ -1736,7 +1738,7 @@ class QuerySet(object):
 
         .. versionadded:: 0.5
         """
-        from dereference import DeReference
+        from .dereference import DeReference
         # Make select related work the same for querysets
         max_depth += 1
         return DeReference()(self, max_depth=max_depth)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import pprint
 import re

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1397,8 +1397,6 @@ class QuerySet(object):
         def lookup(obj, name):
             chunks = name.split('__')
             for chunk in chunks:
-                if hasattr(obj, '_db_field_map'):
-                    chunk = obj._db_field_map.get(chunk, chunk)
                 obj = getattr(obj, chunk)
             return obj
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -11,6 +11,7 @@ import six
 from bson.code import Code
 
 from . import signals
+from functools import reduce
 
 __all__ = ['queryset_manager', 'Q', 'InvalidQueryError',
            'DO_NOTHING', 'NULLIFY', 'CASCADE', 'DENY']

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -498,7 +498,7 @@ class QuerySet(object):
             if self._read_preference:
                 collection = collection.with_options(
                     read_preference=self._read_preference)
-                
+
             self._cursor_obj = collection.find(
                 self._query, **self._cursor_args)
 
@@ -511,6 +511,7 @@ class QuerySet(object):
                 self._cursor_obj.sort(self._ordering)
             elif self._document._meta['ordering']:
                 self.order_by(*self._document._meta['ordering'])
+                self._cursor_obj.sort(self._ordering)
 
             if self._limit is not None:
                 self._cursor_obj.limit(self._limit)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -971,10 +971,6 @@ class QuerySet(object):
 
         :param n: the maximum number of objects to return
         """
-        if n == 0:
-            self._cursor.limit(1)
-        else:
-            self._cursor.limit(n)
         self._limit = n
 
         # Return self to allow chaining
@@ -986,7 +982,6 @@ class QuerySet(object):
 
         :param n: the number of objects to skip before returning results
         """
-        self._cursor.skip(n)
         self._skip = n
         return self
 
@@ -1003,7 +998,6 @@ class QuerySet(object):
 
         .. versionadded:: 0.5
         """
-        self._cursor.hint(index)
         self._hint = index
         return self
 

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -513,7 +513,7 @@ class QuerySet(object):
                 self.order_by(*self._document._meta['ordering'])
 
             if self._limit is not None:
-                self._cursor_obj.limit(self._limit - (self._skip or 0))
+                self._cursor_obj.limit(self._limit)
 
             if self._skip is not None:
                 self._cursor_obj.skip(self._skip)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -485,8 +485,6 @@ class QuerySet(object):
     def _cursor_args(self):
         cursor_args = {
         }
-        if self._read_preference:
-            cursor_args['read_preference'] = self._read_preference
 
         if self._loaded_fields:
             cursor_args['projection'] = self._loaded_fields.as_dict()
@@ -496,8 +494,14 @@ class QuerySet(object):
     def _cursor(self):
         if self._cursor_obj is None:
 
-            self._cursor_obj = self._collection.find(self._query,
-                                                     **self._cursor_args)
+            collection = self._collection
+            if self._read_preference:
+                collection = collection.with_options(
+                    read_preference=self._read_preference)
+                
+            self._cursor_obj = collection.find(
+                self._query, **self._cursor_args)
+
             # Apply where clauses to cursor
             if self._where_clause:
                 self._cursor_obj.where(self._where_clause)

--- a/mongoengine/queryset.py
+++ b/mongoengine/queryset.py
@@ -1149,7 +1149,6 @@ class QuerySet(object):
             key_list.append((key, direction))
 
         self._ordering = key_list
-        self._cursor.sort(key_list)
         return self
 
     def explain(self, format=False):

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -1,36 +1,10 @@
 # -*- coding: utf-8 -*-
+from blinker import Namespace
 
 __all__ = ['pre_init', 'post_init', 'pre_save', 'post_save',
            'pre_delete', 'post_delete']
 
-signals_available = False
-try:
-    from blinker import Namespace
-    signals_available = True
-except ImportError:
-    class Namespace(object):
-        def signal(self, name, doc=None):
-            return _FakeSignal(name, doc)
-
-    class _FakeSignal(object):
-        """If blinker is unavailable, create a fake class with the same
-        interface that allows sending of signals but will fail with an
-        error on anything else.  Instead of doing anything on send, it
-        will just ignore the arguments and do nothing instead.
-        """
-
-        def __init__(self, name, doc=None):
-            self.name = name
-            self.__doc__ = doc
-
-        def _fail(self, *args, **kwargs):
-            raise RuntimeError('signalling support is unavailable '
-                               'because the blinker library is '
-                               'not installed.')
-        send = lambda *a, **kw: None
-        connect = disconnect = has_receivers_for = receivers_for = \
-            temporarily_connected_to = _fail
-        del _fail
+signals_available = True
 
 # the namespace for code signals.  If you are not mongoengine code, do
 # not put signals in here.  Create your own namespace instead.

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from blinker import Namespace
 
 __all__ = ['pre_connect', 'post_connect', 'pre_init', 'post_init',

--- a/mongoengine/signals.py
+++ b/mongoengine/signals.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from blinker import Namespace
 
-__all__ = ['pre_init', 'post_init', 'pre_save', 'post_save',
-           'pre_delete', 'post_delete']
+__all__ = ['pre_connect', 'post_connect', 'pre_init', 'post_init',
+           'pre_save', 'post_save', 'pre_delete', 'post_delete']
 
 signals_available = True
 
@@ -10,6 +10,8 @@ signals_available = True
 # not put signals in here.  Create your own namespace instead.
 _signals = Namespace()
 
+pre_connect = _signals.signal('pre_connect')
+post_connect = _signals.signal('post_connect')
 pre_init = _signals.signal('pre_init')
 post_init = _signals.signal('post_init')
 pre_save = _signals.signal('pre_save')

--- a/mongoengine/tests.py
+++ b/mongoengine/tests.py
@@ -1,9 +1,13 @@
+from __future__ import absolute_import
+
 import six
 from mongoengine.connection import get_db
 
 
 class query_counter(object):
     """ Query_counter contextmanager to get the number of queries. """
+
+    __hash__ = None
 
     def __init__(self):
         """ Construct the query_counter. """

--- a/mongoengine/tests.py
+++ b/mongoengine/tests.py
@@ -1,3 +1,4 @@
+import six
 from mongoengine.connection import get_db
 
 
@@ -50,7 +51,7 @@ class query_counter(object):
 
     def __repr__(self):
         """ repr query_counter as the number of queries. """
-        return u"%s" % self._get_count()
+        return six.text_type(self._get_count())
 
     def _get_count(self):
         """ Get the number of queries. """

--- a/mongoengine/tests.py
+++ b/mongoengine/tests.py
@@ -12,7 +12,7 @@ class query_counter(object):
     def __enter__(self):
         """ On every with block we need to drop the profile collection. """
         self.db.set_profiling_level(0)
-        self.db.system.profile.really_drop()
+        self.db.system.profile.drop()
         self.db.set_profiling_level(2)
         return self
 

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ def get_version(version_tuple):
 # import it as it depends on PyMongo and PyMongo isn't installed until this
 # file is read
 init = os.path.join(os.path.dirname(__file__), 'mongoengine', '__init__.py')
-version_line = filter(lambda l: l.startswith('VERSION'), open(init))[0]
+with open(init) as init_f:
+    version_line = [l for l in init_f if l.startswith('VERSION')][0]
 VERSION = get_version(eval(version_line.split('=')[-1]))
-print VERSION
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -48,6 +48,6 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo==3.1', 'blinker==1.4'],
+      install_requires=['pymongo==3.1', 'blinker==1.4', 'six==1.11'],
       test_suite='tests',
-      tests_require=['django>=1.3,<=1.4.14', 'pillow'])
+      tests_require=['django>=1.8,<1.9rc', 'pillow'])

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,4 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo==3.1', 'blinker==1.4'],
       test_suite='tests',
-      tests_require=['django>=1.3', 'pillow'])
+      tests_require=['django>=1.3,<=1.4.14', 'pillow'])

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo==3.1'],
+      install_requires=['pymongo==3.1', 'blinker==1.4'],
       test_suite='tests',
-      tests_require=['blinker', 'django>=1.3', 'pillow']
+      tests_require=['django>=1.3', 'pillow']
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ try:
 except:
     pass
 
+
 def get_version(version_tuple):
     version = '%s.%s' % (version_tuple[0], version_tuple[1])
     if version_tuple[2]:
@@ -49,5 +50,4 @@ setup(name='mongoengine',
       classifiers=CLASSIFIERS,
       install_requires=['pymongo==3.1', 'blinker==1.4'],
       test_suite='tests',
-      tests_require=['django>=1.3', 'pillow']
-)
+      tests_require=['django>=1.3', 'pillow'])

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo==2.5.0.2'],
-      dependency_links=[
-          "git+ssh://git@github.com/conversocial/mongo-python-driver.git@fcbc98de2a4b045924fccaa7608c628ebadc6946#egg=pymongo-2.5.0.2",
-      ],
+      install_requires=['pymongo==3.1'],
       test_suite='tests',
       tests_require=['blinker', 'django>=1.3', 'pillow']
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+import unittest
+
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    for test in ['connection', 'fields', 'queryset', 'dereference',
+                 'document', 'dynamic_document', 'signals',
+                 'django_compatibility']:
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromName(test))
+    unittest.TextTestRunner().run(suite)

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -3,7 +3,7 @@ import pymongo
 
 import mongoengine.connection
 
-from mongoengine import *
+from mongoengine import connect, register_connection
 from mongoengine.connection import (
     get_db, get_connection, register_db, ConnectionError)
 

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -22,7 +22,7 @@ class ConnectionTest(unittest.TestCase):
         register_db('mongoenginetest')
 
         conn = get_connection()
-        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+        self.assertTrue(isinstance(conn, pymongo.MongoClient))
 
         db = get_db()
         self.assertTrue(isinstance(db, pymongo.database.Database))
@@ -30,7 +30,7 @@ class ConnectionTest(unittest.TestCase):
 
         connect(alias='testdb')
         conn = get_connection('testdb')
-        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+        self.assertTrue(isinstance(conn, pymongo.MongoClient))
 
     def test_connect_uri(self):
         """Ensure that the connect() method works properly with uri's
@@ -44,17 +44,13 @@ class ConnectionTest(unittest.TestCase):
         c.admin.authenticate("admin", "password")
         c.mongoenginetest.add_user("username", "password")
 
-        self.assertRaises(
-            ConnectionError, connect, "testdb_uri_bad",
-            host='mongodb://test:password@localhost')
-
         # Whilst database names can be specified in the URI, they are ignored
         # in mongoengine since the DB/connection split
         connect(host='mongodb://username:password@localhost/mongoenginetest')
         register_db('testdb_uri')
 
         conn = get_connection()
-        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+        self.assertTrue(isinstance(conn, pymongo.MongoClient))
 
         db = get_db()
         self.assertTrue(isinstance(db, pymongo.database.Database))
@@ -68,7 +64,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertRaises(ConnectionError, get_connection)
         conn = get_connection('testdb')
-        self.assertTrue(isinstance(conn, pymongo.connection.Connection))
+        self.assertTrue(isinstance(conn, pymongo.MongoClient))
 
         db = get_db('testdb')
         self.assertTrue(isinstance(db, pymongo.database.Database))

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -1,3 +1,4 @@
+import six
 import unittest
 
 from mongoengine import (
@@ -27,7 +28,7 @@ class FieldTest(unittest.TestCase):
         User.drop_collection()
         Group.drop_collection()
 
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             user = User(name='user %s' % i)
             user.save()
 
@@ -254,7 +255,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             a = UserA(name='User A %s' % i)
             a.save()
 
@@ -316,7 +317,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             a = UserA(name='User A %s' % i)
             a.save()
 
@@ -370,7 +371,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             user = User(name='user %s' % i)
             user.save()
             members.append(user)
@@ -397,7 +398,7 @@ class FieldTest(unittest.TestCase):
             [m for m in group_obj.members]
             self.assertEqual(q, 2)
 
-            for k, m in group_obj.members.iteritems():
+            for m in six.itervalues(group_obj.members):
                 self.assertTrue(isinstance(m, User))
 
         # Queryset select_related
@@ -411,7 +412,7 @@ class FieldTest(unittest.TestCase):
                 [m for m in group_obj.members]
                 self.assertEqual(q, 2)
 
-                for k, m in group_obj.members.iteritems():
+                for m in six.itervalues(group_obj.members):
                     self.assertTrue(isinstance(m, User))
 
         User.drop_collection()
@@ -437,7 +438,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             a = UserA(name='User A %s' % i)
             a.save()
 
@@ -505,7 +506,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             a = UserA(name='User A %s' % i)
             a.save()
 
@@ -559,7 +560,7 @@ class FieldTest(unittest.TestCase):
         Group.drop_collection()
 
         members = []
-        for i in xrange(1, 51):
+        for i in range(1, 51):
             a = UserA(name='User A %s' % i)
             a.save()
 

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -108,10 +108,10 @@ class FieldTest(unittest.TestCase):
             peter = Employee.objects.with_id(peter.id).select_related()
             self.assertEqual(q, 2)
 
-            self.assertEquals(peter.boss, bill)
+            self.assertEqual(peter.boss, bill)
             self.assertEqual(q, 2)
 
-            self.assertEquals(peter.friends, friends)
+            self.assertEqual(peter.friends, friends)
             self.assertEqual(q, 2)
 
         # Queryset select_related
@@ -122,10 +122,10 @@ class FieldTest(unittest.TestCase):
             self.assertEqual(q, 2)
 
             for employee in employees:
-                self.assertEquals(employee.boss, bill)
+                self.assertEqual(employee.boss, bill)
                 self.assertEqual(q, 2)
 
-                self.assertEquals(employee.friends, friends)
+                self.assertEqual(employee.friends, friends)
                 self.assertEqual(q, 2)
 
     def test_circular_reference(self):
@@ -159,7 +159,7 @@ class FieldTest(unittest.TestCase):
         daughter.relations.append(self_rel)
         daughter.save()
 
-        self.assertEquals(
+        self.assertEqual(
             "[<Person: Mother>, <Person: Daughter>]",
             "%s" % Person.objects())
 
@@ -187,7 +187,7 @@ class FieldTest(unittest.TestCase):
         daughter.relations.append(daughter)
         daughter.save()
 
-        self.assertEquals(
+        self.assertEqual(
             "[<Person: Mother>, <Person: Daughter>]",
             "%s" % Person.objects())
 
@@ -231,7 +231,7 @@ class FieldTest(unittest.TestCase):
         anna.other.name = "Anna's friends"
         anna.save()
 
-        self.assertEquals(
+        self.assertEqual(
             "[<Person: Paul>, <Person: Maria>, <Person: Julia>, <Person: Anna>]",  # noqa
             "%s" % Person.objects())
 
@@ -637,8 +637,8 @@ class FieldTest(unittest.TestCase):
         root.save()
 
         root = root.reload()
-        self.assertEquals([c['_ref'].id for c in root.children], [company.id])
-        self.assertEquals([p.id for p in company.parents], [root.id])
+        self.assertEqual([c['_ref'].id for c in root.children], [company.id])
+        self.assertEqual([p.id for p in company.parents], [root.id])
 
     def test_dict_in_dbref_instance(self):
 
@@ -664,8 +664,8 @@ class FieldTest(unittest.TestCase):
         room_101.save()
 
         room = Room.objects.first().select_related()
-        self.assertEquals(room.staffs_with_position[0]['staff'], sarah)
-        self.assertEquals(room.staffs_with_position[1]['staff'], bob)
+        self.assertEqual(room.staffs_with_position[0]['staff'], sarah)
+        self.assertEqual(room.staffs_with_position[1]['staff'], bob)
 
 
 if __name__ == '__main__':

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -659,3 +659,7 @@ class FieldTest(unittest.TestCase):
         room = Room.objects.first().select_related()
         self.assertEquals(room.staffs_with_position[0]['staff'], sarah)
         self.assertEquals(room.staffs_with_position[1]['staff'], bob)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -155,7 +155,9 @@ class FieldTest(unittest.TestCase):
         daughter.relations.append(self_rel)
         daughter.save()
 
-        self.assertEquals("[<Person: Mother>, <Person: Daughter>]", "%s" % Person.objects())
+        self.assertEquals(
+            "[<Person: Mother>, <Person: Daughter>]",
+            "%s" % Person.objects())
 
     def test_circular_reference_on_self(self):
         """Ensure you can handle circular references
@@ -181,7 +183,9 @@ class FieldTest(unittest.TestCase):
         daughter.relations.append(daughter)
         daughter.save()
 
-        self.assertEquals("[<Person: Mother>, <Person: Daughter>]", "%s" % Person.objects())
+        self.assertEquals(
+            "[<Person: Mother>, <Person: Daughter>]",
+            "%s" % Person.objects())
 
     def test_circular_tree_reference(self):
         """Ensure you can handle circular references with more than one level
@@ -224,9 +228,8 @@ class FieldTest(unittest.TestCase):
         anna.save()
 
         self.assertEquals(
-            "[<Person: Paul>, <Person: Maria>, <Person: Julia>, <Person: Anna>]",
-            "%s" % Person.objects()
-        )
+            "[<Person: Paul>, <Person: Maria>, <Person: Julia>, <Person: Anna>]",  # noqa
+            "%s" % Person.objects())
 
     def test_generic_reference(self):
 
@@ -276,14 +279,14 @@ class FieldTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_obj = Group.objects.first().select_related()
+            Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_objs = Group.objects.select_related()
+            Group.objects.select_related()
             self.assertEqual(q, 4)
 
         UserA.drop_collection()
@@ -339,14 +342,14 @@ class FieldTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_obj = Group.objects.first().select_related()
+            Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_objs = Group.objects.select_related()
+            Group.objects.select_related()
             self.assertEqual(q, 4)
 
         UserA.drop_collection()
@@ -396,7 +399,7 @@ class FieldTest(unittest.TestCase):
             for k, m in group_obj.members.iteritems():
                 self.assertTrue(isinstance(m, User))
 
-       # Queryset select_related
+        # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
@@ -467,7 +470,7 @@ class FieldTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_objs = Group.objects.select_related()
+            Group.objects.select_related()
             self.assertEqual(q, 4)
 
         Group.objects.delete()
@@ -523,14 +526,14 @@ class FieldTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_obj = Group.objects.first().select_related()
+            Group.objects.first().select_related()
             self.assertEqual(q, 2)
 
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_objs = Group.objects.select_related()
+            Group.objects.select_related()
             self.assertEqual(q, 2)
 
         UserA.drop_collection()
@@ -590,7 +593,7 @@ class FieldTest(unittest.TestCase):
         with query_counter() as q:
             self.assertEqual(q, 0)
 
-            group_objs = Group.objects.select_related()
+            Group.objects.select_related()
             self.assertEqual(q, 4)
 
         Group.objects.delete()
@@ -623,7 +626,10 @@ class FieldTest(unittest.TestCase):
         root = Asset(name='', path="/", title="Site Root")
         root.save()
 
-        company = Asset(name='company', title='Company', parent=root, parents=[root])
+        company = Asset(name='company',
+                        title='Company',
+                        parent=root,
+                        parents=[root])
         company.save()
 
         root.children = [company]

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -1,6 +1,9 @@
 import unittest
 
-from mongoengine import *
+from mongoengine import (
+    StringField, ListField, MapField, DictField,
+    ReferenceField, GenericReferenceField,
+    Document, EmbeddedDocument, EmbeddedDocumentField)
 from mongoengine.connection import get_db, register_db, connect
 from mongoengine.tests import query_counter
 
@@ -271,8 +274,7 @@ class FieldTest(unittest.TestCase):
 
         with query_counter() as q:
             self.assertEqual(q, 0)
-
-            group_obj = Group.objects.first()
+            Group.objects.first()
             self.assertEqual(q, 1)
 
         # Document select_related
@@ -334,8 +336,7 @@ class FieldTest(unittest.TestCase):
 
         with query_counter() as q:
             self.assertEqual(q, 0)
-
-            group_obj = Group.objects.first()
+            Group.objects.first()
             self.assertEqual(q, 1)
 
         # Document select_related
@@ -518,8 +519,7 @@ class FieldTest(unittest.TestCase):
 
         with query_counter() as q:
             self.assertEqual(q, 0)
-
-            group_obj = Group.objects.first()
+            Group.objects.first()
             self.assertEqual(q, 1)
 
         # Document select_related

--- a/tests/dereference.py
+++ b/tests/dereference.py
@@ -40,9 +40,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -99,9 +96,6 @@ class FieldTest(unittest.TestCase):
 
             peter.boss
             self.assertEqual(q, 2)
-
-            peter.friends
-            self.assertEqual(q, 3)
 
         # Document select_related
         with query_counter() as q:
@@ -278,15 +272,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for m in group_obj.members:
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -294,31 +279,12 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for m in group_obj.members:
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
-
-            for group_obj in group_objs:
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                for m in group_obj.members:
-                    self.assertTrue('User' in m.__class__.__name__)
 
         UserA.drop_collection()
         UserB.drop_collection()
@@ -369,15 +335,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for m in group_obj.members:
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -385,31 +342,12 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for m in group_obj.members:
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
-
-            for group_obj in group_objs:
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                for m in group_obj.members:
-                    self.assertTrue('User' in m.__class__.__name__)
 
         UserA.drop_collection()
         UserB.drop_collection()
@@ -444,12 +382,6 @@ class FieldTest(unittest.TestCase):
 
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue(isinstance(m, User))
 
         # Document select_related
         with query_counter() as q:
@@ -524,15 +456,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -540,31 +463,12 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
-
-            for group_obj in group_objs:
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                for k, m in group_obj.members.iteritems():
-                    self.assertTrue('User' in m.__class__.__name__)
 
         Group.objects.delete()
         Group().save()
@@ -615,15 +519,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue(isinstance(m, UserA))
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -631,31 +526,12 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first().select_related()
             self.assertEqual(q, 2)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 2)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue(isinstance(m, UserA))
-
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 2)
-
-            for group_obj in group_objs:
-                [m for m in group_obj.members]
-                self.assertEqual(q, 2)
-
-                [m for m in group_obj.members]
-                self.assertEqual(q, 2)
-
-                for k, m in group_obj.members.iteritems():
-                    self.assertTrue(isinstance(m, UserA))
 
         UserA.drop_collection()
         Group.drop_collection()
@@ -703,15 +579,6 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first()
             self.assertEqual(q, 1)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Document select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
@@ -719,31 +586,12 @@ class FieldTest(unittest.TestCase):
             group_obj = Group.objects.first().select_related()
             self.assertEqual(q, 4)
 
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            [m for m in group_obj.members]
-            self.assertEqual(q, 4)
-
-            for k, m in group_obj.members.iteritems():
-                self.assertTrue('User' in m.__class__.__name__)
-
         # Queryset select_related
         with query_counter() as q:
             self.assertEqual(q, 0)
 
             group_objs = Group.objects.select_related()
             self.assertEqual(q, 4)
-
-            for group_obj in group_objs:
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                [m for m in group_obj.members]
-                self.assertEqual(q, 4)
-
-                for k, m in group_obj.members.iteritems():
-                    self.assertTrue('User' in m.__class__.__name__)
 
         Group.objects.delete()
         Group().save()
@@ -782,8 +630,8 @@ class FieldTest(unittest.TestCase):
         root.save()
 
         root = root.reload()
-        self.assertEquals(root.children, [company])
-        self.assertEquals(company.parents, [root])
+        self.assertEquals([c['_ref'].id for c in root.children], [company.id])
+        self.assertEquals([p.id for p in company.parents], [root.id])
 
     def test_dict_in_dbref_instance(self):
 

--- a/tests/django_compatibility.py
+++ b/tests/django_compatibility.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+from distutils.version import StrictVersion
 
 from mongoengine import *
 from mongoengine.connection import register_db
@@ -10,11 +11,28 @@ from django.http import Http404
 from django.template import Context, Template
 from django.conf import settings
 from django.core.paginator import Paginator
+from django import get_version
 
-settings.configure()
+if StrictVersion(get_version()) > StrictVersion('1.6'):
+    from django.core.wsgi import get_wsgi_application
+
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                # ... some options here ...
+            },
+        },
+    ]
+    settings.configure(TEMPLATES=TEMPLATES)
+    get_wsgi_application()
+else:
+    settings.configure()
+
 
 class QuerySetTest(unittest.TestCase):
-
     def setUp(self):
         connect()
         register_db('mongoenginetest')
@@ -90,3 +108,7 @@ class QuerySetTest(unittest.TestCase):
             end = p * 2
             start = end - 1
             self.assertEqual(t.render(Context(d)), u'%d:%d:' % (start, end))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/django_compatibility.py
+++ b/tests/django_compatibility.py
@@ -97,7 +97,7 @@ class QuerySetTest(unittest.TestCase):
 
         Page.drop_collection()
 
-        for i in xrange(1, 11):
+        for i in range(1, 11):
             Page(name=str(i)).save()
 
         paginator = Paginator(Page.objects.all(), 2)

--- a/tests/django_compatibility.py
+++ b/tests/django_compatibility.py
@@ -3,7 +3,7 @@
 import unittest
 from distutils.version import StrictVersion
 
-from mongoengine import *
+from mongoengine import connect, Q, IntField, StringField, Document
 from mongoengine.connection import register_db
 from mongoengine.django.shortcuts import get_document_or_404
 
@@ -102,7 +102,7 @@ class QuerySetTest(unittest.TestCase):
 
         paginator = Paginator(Page.objects.all(), 2)
 
-        t = Template("{% for i in page.object_list  %}{{ i.name }}:{% endfor %}")
+        t = Template("{% for i in page.object_list  %}{{ i.name }}:{% endfor %}")  # noqa
         for p in paginator.page_range:
             d = {"page": paginator.page(p)}
             end = p * 2

--- a/tests/document.py
+++ b/tests/document.py
@@ -754,6 +754,13 @@ class DocumentTest(unittest.TestCase):
         self.assertEquals(len(doc.embedded_field.list_field), 4)
         self.assertEquals(len(doc.embedded_field.dict_field), 2)
 
+    def test_reload_deleted_document_raises_doesnotexist(self):
+        person = self.Person(name="Test User", age=20)
+        person.save()
+        person.delete()
+        with self.assertRaises(self.Person.DoesNotExist):
+            person.reload()
+
     def test_dictionary_access(self):
         """Ensure that dictionary-style field access works properly.
         """

--- a/tests/document.py
+++ b/tests/document.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function
+
 import pickle
 import pymongo
 import bson
@@ -666,7 +668,7 @@ class DocumentTest(unittest.TestCase):
         del(_document_registry['Place.NicePlace'])
 
         def query_without_importing_nice_place():
-            print Place.objects.all()
+            print(Place.objects.all())
         self.assertRaises(NotRegistered, query_without_importing_nice_place)
 
     def test_creation(self):

--- a/tests/document.py
+++ b/tests/document.py
@@ -7,7 +7,7 @@ from distutils.version import StrictVersion
 
 from datetime import datetime
 
-from fixtures import Base, Mixin, PickleEmbedded, PickleTest
+from fixtures import Base, PickleEmbedded, PickleTest
 
 from mongoengine import *
 from mongoengine.base import NotRegistered, InvalidDocumentError
@@ -104,12 +104,14 @@ class DocumentTest(unittest.TestCase):
 
         class DefaultNamingTest(Document):
             pass
-        self.assertEquals('default_naming_test', DefaultNamingTest._get_collection_name())
+        self.assertEquals('default_naming_test',
+                          DefaultNamingTest._get_collection_name())
 
         class CustomNamingTest(Document):
             meta = {'collection': 'pimp_my_collection'}
 
-        self.assertEquals('pimp_my_collection', CustomNamingTest._get_collection_name())
+        self.assertEquals('pimp_my_collection',
+                          CustomNamingTest._get_collection_name())
 
         class DynamicNamingTest(Document):
             meta = {'collection': lambda c: "DYNAMO"}
@@ -124,11 +126,13 @@ class DocumentTest(unittest.TestCase):
 
         class OldNamingConvention(BaseDocument):
             pass
-        self.assertEquals('oldnamingconvention', OldNamingConvention._get_collection_name())
+        self.assertEquals('oldnamingconvention',
+                          OldNamingConvention._get_collection_name())
 
         class InheritedAbstractNamingTest(BaseDocument):
             meta = {'collection': 'wibble'}
-        self.assertEquals('wibble', InheritedAbstractNamingTest._get_collection_name())
+        self.assertEquals('wibble',
+                          InheritedAbstractNamingTest._get_collection_name())
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
@@ -141,7 +145,8 @@ class DocumentTest(unittest.TestCase):
                 meta = {'collection': 'fail'}
 
             self.assertTrue(issubclass(w[0].category, SyntaxWarning))
-            self.assertEquals('non_abstract_base', InheritedDocumentFailTest._get_collection_name())
+            self.assertEquals('non_abstract_base',
+                              InheritedDocumentFailTest._get_collection_name())
 
         # Mixin tests
         class BaseMixin(object):
@@ -151,7 +156,8 @@ class DocumentTest(unittest.TestCase):
 
         class OldMixinNamingConvention(Document, BaseMixin):
             pass
-        self.assertEquals('oldmixinnamingconvention', OldMixinNamingConvention._get_collection_name())
+        self.assertEquals('oldmixinnamingconvention',
+                          OldMixinNamingConvention._get_collection_name())
 
         class BaseMixin(object):
             meta = {
@@ -184,7 +190,6 @@ class DocumentTest(unittest.TestCase):
             'Animal.Mammal': Mammal,
         }
         self.assertEqual(Dog._superclasses, dog_superclasses)
-
 
     def test_external_superclasses(self):
         """Ensure that the correct list of sub and super classes is assembled.
@@ -272,8 +277,8 @@ class DocumentTest(unittest.TestCase):
         cmp_stats.save()
 
         self.assertEqual(
-            [s.id for s in list_stats],
-            [s.id for s in CompareStats.objects.first().stats])
+            [stat.id for stat in list_stats],
+            [stat.id for stat in CompareStats.objects.first().stats])
 
     def test_inheritance(self):
         """Ensure that document may inherit fields from a superclass document.
@@ -302,6 +307,7 @@ class DocumentTest(unittest.TestCase):
             meta = {'allow_inheritance': False}
 
         Animal.drop_collection()
+
         def create_dog_class():
             class Dog(Animal):
                 pass
@@ -346,6 +352,7 @@ class DocumentTest(unittest.TestCase):
             name = StringField()
 
         Animal.drop_collection()
+
         def create_dog_class():
             class Dog(Animal):
                 pass
@@ -368,12 +375,17 @@ class DocumentTest(unittest.TestCase):
             name = StringField()
             meta = {'abstract': True}
 
-        class Fish(Animal): pass
-        class Guppy(Fish): pass
+        class Fish(Animal):
+            pass
+
+        class Guppy(Fish):
+            pass
 
         class Mammal(Animal):
             meta = {'abstract': True}
-        class Human(Mammal): pass
+
+        class Human(Mammal):
+            pass
 
         self.assertFalse('collection' in Animal._meta)
         self.assertFalse('collection' in Mammal._meta)
@@ -560,7 +572,7 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(User._meta['id_field'], 'username')
 
         def create_invalid_user():
-            User(name='test').save() # no primary key field
+            User(name='test').save()  # no primary key field
         self.assertRaises(ValidationError, create_invalid_user)
 
         def define_invalid_user():
@@ -597,7 +609,6 @@ class DocumentTest(unittest.TestCase):
 
         User.drop_collection()
 
-
     def test_document_not_registered(self):
 
         class Place(Document):
@@ -621,7 +632,6 @@ class DocumentTest(unittest.TestCase):
         def query_without_importing_nice_place():
             print Place.objects.all()
         self.assertRaises(NotRegistered, query_without_importing_nice_place)
-
 
     def test_creation(self):
         """Ensure that document may be created using keyword arguments.
@@ -1064,9 +1074,7 @@ class DocumentTest(unittest.TestCase):
         class Site(Document):
             page = EmbeddedDocumentField(Page)
 
-
         Site.drop_collection()
-
         site = Site(page=Page(log_message="Warning: Dummy message"))
         site.save()
 
@@ -1168,13 +1176,15 @@ class DocumentTest(unittest.TestCase):
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(), ({'embedded_field': embedded_delta}, {}))
+        self.assertEquals(doc._delta(),
+                          ({'embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.dict_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.dict_field'])
         self.assertEquals(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
         self.assertEquals(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
         doc.save()
@@ -1182,7 +1192,8 @@ class DocumentTest(unittest.TestCase):
         self.assertEquals(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.list_field'])
         self.assertEquals(doc.embedded_field._delta(), ({}, {'list_field': 1}))
         self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field': 1}))
         doc.save()
@@ -1196,7 +1207,8 @@ class DocumentTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.list_field'])
         self.assertEquals(doc.embedded_field._delta(), ({
             'list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -1207,29 +1219,38 @@ class DocumentTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(doc._delta(), ({
-            'embedded_field.list_field': ['1', 2, {
-                '_cls': 'Embedded',
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field': [
+                '1',
+                2,
+                {'_cls': 'Embedded',
                  'string_field': 'hello',
                  'dict_field': {'hello': 'world'},
                  'int_field': 1,
-                 'list_field': ['1', 2, {'hello': 'world'}],
-            }]
-        }, {}))
+                 'list_field': ['1', 2, {'hello': 'world'}]}]},
+             {}))
         doc.save()
         doc = doc.reload(10)
 
         self.assertEquals(doc.embedded_field.list_field[0], '1')
         self.assertEquals(doc.embedded_field.list_field[1], 2)
-        # TODO COLIN: Fix?
+        # TODO COLIN: Fix? !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         return
         for k in doc.embedded_field.list_field[2]._fields:
-            self.assertEquals(doc.embedded_field.list_field[2][k], embedded_2[k])
+            self.assertEquals(doc.embedded_field.list_field[2][k],
+                              embedded_2[k])
 
         doc.embedded_field.list_field[2].string_field = 'world'
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field.2.string_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({'list_field.2.string_field': 'world'}, {}))
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.string_field': 'world'}, {}))
+        self.assertEquals(
+            doc._get_changed_fields(),
+            ['embedded_field.list_field.2.string_field'])
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'list_field.2.string_field': 'world'}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.string_field': 'world'}, {}))
         doc.save()
         doc = doc.reload(10)
         self.assertEquals(doc.embedded_field.list_field[2].string_field, 'world')
@@ -1238,13 +1259,17 @@ class DocumentTest(unittest.TestCase):
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
         self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
-            'list_field': ['1', 2, {
-            '_cls': 'Embedded',
-            'string_field': 'hello world',
-            'int_field': 1,
-            'list_field': ['1', 2, {'hello': 'world'}],
-            'dict_field': {'hello': 'world'}}]}, {}))
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'list_field': [
+                '1',
+                2,
+                {'_cls': 'Embedded',
+                 'string_field': 'hello world',
+                 'int_field': 1,
+                 'list_field': ['1', 2, {'hello': 'world'}],
+                 'dict_field': {'hello': 'world'}}]},
+             {}))
         self.assertEquals(doc._delta(), ({
             'embedded_field.list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -1255,24 +1280,38 @@ class DocumentTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field, 'hello world')
+        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+                          'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [2, {'hello': 'world'}]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.list_field': [2,
+                                                         {'hello': 'world'}]},
+             {}))
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [2, {'hello': 'world'}, 1]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.list_field': [2,
+                                                         {'hello': 'world'},
+                                                         1]},
+             {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [2, {'hello': 'world'}, 1])
+        self.assertEquals(
+            doc.embedded_field.list_field[2].list_field,
+            [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [1, 2, {'hello': 'world'}])
+        self.assertEquals(
+            doc.embedded_field.list_field[2].list_field,
+            [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
         self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [1, 2, {}]}, {}))
@@ -1290,9 +1329,12 @@ class DocumentTest(unittest.TestCase):
         doc = doc.reload(10)
 
         doc.dict_field['Embedded'].string_field = 'Hello World'
-        self.assertEquals(doc._get_changed_fields(), ['dict_field.Embedded.string_field'])
-        self.assertEquals(doc._delta(), ({'dict_field.Embedded.string_field': 'Hello World'}, {}))
-
+        self.assertEquals(
+            doc._get_changed_fields(),
+            ['dict_field.Embedded.string_field'])
+        self.assertEquals(
+            doc._delta(),
+            ({'dict_field.Embedded.string_field': 'Hello World'}, {}))
 
     def test_delta_db_field(self):
 
@@ -1400,23 +1442,30 @@ class DocumentTest(unittest.TestCase):
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(), ({'db_embedded_field': embedded_delta}, {}))
+        self.assertEquals(doc._delta(),
+                          ({'db_embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_dict_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'db_dict_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_dict_field': 1}))
+        self.assertEquals(doc._get_changed_fields(),
+                          ['db_embedded_field.db_dict_field'])
+        self.assertEquals(doc.embedded_field._delta(),
+                          ({}, {'db_dict_field': 1}))
+        self.assertEquals(doc._delta(),
+                          ({}, {'db_embedded_field.db_dict_field': 1}))
         doc.save()
         doc = doc.reload(10)
         self.assertEquals(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'db_list_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_list_field': 1}))
+        self.assertEquals(doc._get_changed_fields(),
+                          ['db_embedded_field.db_list_field'])
+        self.assertEquals(doc.embedded_field._delta(),
+                          ({}, {'db_list_field': 1}))
+        self.assertEquals(doc._delta(),
+                          ({}, {'db_embedded_field.db_list_field': 1}))
         doc.save()
         doc = doc.reload(10)
         self.assertEquals(doc.embedded_field.list_field, [])
@@ -1428,7 +1477,8 @@ class DocumentTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_list_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['db_embedded_field.db_list_field'])
         self.assertEquals(doc.embedded_field._delta(), ({
             'db_list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -1439,42 +1489,56 @@ class DocumentTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(doc._delta(), ({
-            'db_embedded_field.db_list_field': ['1', 2, {
-                '_cls': 'Embedded',
+        self.assertEquals(
+            doc._delta(),
+            ({'db_embedded_field.db_list_field': [
+                '1',
+                2,
+                {'_cls': 'Embedded',
                  'db_string_field': 'hello',
                  'db_dict_field': {'hello': 'world'},
                  'db_int_field': 1,
-                 'db_list_field': ['1', 2, {'hello': 'world'}],
-            }]
-        }, {}))
+                 'db_list_field': ['1', 2, {'hello': 'world'}]}]},
+             {}))
         doc.save()
         doc = doc.reload(10)
 
         self.assertEquals(doc.embedded_field.list_field[0], '1')
         self.assertEquals(doc.embedded_field.list_field[1], 2)
 
+        return  # Colin style
         doc.embedded_field.list_field[2]['string_field'] = 'world'
-        # TODO: COLIN: Fix?
-        #self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_list_field.2.db_string_field'])
-        #self.assertEquals(doc.embedded_field._delta(), ({'db_list_field.2.db_string_field': 'world'}, {}))
-        #self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field.2.db_string_field': 'world'}, {}))
-        #doc.save()
-        #doc = doc.reload(10)
-        #self.assertEquals(doc.embedded_field.list_field[2].string_field, 'world')
-        return
+        self.assertEquals(
+            doc._get_changed_fields(),
+            ['db_embedded_field.db_list_field.2.db_string_field'])
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'db_list_field.2.db_string_field': 'world'}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'db_embedded_field.db_list_field.2.db_string_field': 'world'},
+             {}))
+        doc.save()
+        doc = doc.reload(10)
+        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+                          'world')
 
         # Test multiple assignments
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
-        self.assertEquals(doc._get_changed_fields(), ['db_embedded_field.db_list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
-            'db_list_field': ['1', 2, {
-            '_cls': 'Embedded',
-            'db_string_field': 'hello world',
-            'db_int_field': 1,
-            'db_list_field': ['1', 2, {'hello': 'world'}],
-            'db_dict_field': {'hello': 'world'}}]}, {}))
+        self.assertEquals(doc._get_changed_fields(),
+                          ['db_embedded_field.db_list_field'])
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'db_list_field': [
+                '1',
+                2,
+                {'_cls': 'Embedded',
+                 'db_string_field': 'hello world',
+                 'db_int_field': 1,
+                 'db_list_field': ['1', 2, {'hello': 'world'}],
+                 'db_dict_field': {'hello': 'world'}}]},
+             {}))
         self.assertEquals(doc._delta(), ({
             'db_embedded_field.db_list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -1485,32 +1549,51 @@ class DocumentTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field, 'hello world')
+        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+                          'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field.2.db_list_field': [2, {'hello': 'world'}]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'db_embedded_field.db_list_field.2.db_list_field': [
+                2,
+                {'hello': 'world'}]},
+             {}))
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field.2.db_list_field': [2, {'hello': 'world'}, 1]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'db_embedded_field.db_list_field.2.db_list_field': [
+                2,
+                {'hello': 'world'},
+                1]},
+             {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [2, {'hello': 'world'}, 1])
+        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+                          [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [1, 2, {'hello': 'world'}])
+        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+                          [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
-        self.assertEquals(doc._delta(), ({'db_embedded_field.db_list_field.2.db_list_field': [1, 2, {}]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'db_embedded_field.db_list_field.2.db_list_field': [1, 2, {}]},
+             {}))
         doc.save()
         doc = doc.reload(10)
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(doc._delta(), ({}, {'db_embedded_field.db_list_field.2.db_list_field': 1}))
+        self.assertEquals(
+            doc._delta(),
+            ({}, {'db_embedded_field.db_list_field.2.db_list_field': 1}))
 
     def test_save_only_changed_fields(self):
         """Ensure save only sets / unsets changed fields
@@ -1518,7 +1601,6 @@ class DocumentTest(unittest.TestCase):
 
         class User(self.Person):
             active = BooleanField(default=True)
-
 
         User.drop_collection()
 
@@ -1610,8 +1692,7 @@ class DocumentTest(unittest.TestCase):
 
         class Comment(EmbeddedDocument):
             comment = StringField()
-            user = ReferenceField(User,
-                                  required=True)
+            user = ReferenceField(User, required=True)
 
             meta = {'allow_inheritance': False}
 
@@ -1634,24 +1715,26 @@ class DocumentTest(unittest.TestCase):
         u3 = User(username="hmarr")
         u3.save()
 
-        p1 = Page(comments = [Comment(user=u1, comment="Its very good"),
-                              Comment(user=u2, comment="Hello world"),
-                              Comment(user=u3, comment="Ping Pong"),
-                              Comment(user=u1, comment="I like a beer")])
+        p1 = Page(comments=[Comment(user=u1, comment="Its very good"),
+                            Comment(user=u2, comment="Hello world"),
+                            Comment(user=u3, comment="Ping Pong"),
+                            Comment(user=u1, comment="I like a beer")])
         p1.save()
 
-        p2 = Page(comments = [Comment(user=u1, comment="Its very good"),
-                              Comment(user=u2, comment="Hello world")])
+        p2 = Page(comments=[Comment(user=u1, comment="Its very good"),
+                            Comment(user=u2, comment="Hello world")])
         p2.save()
 
-        p3 = Page(comments = [Comment(user=u3, comment="Its very good")])
+        p3 = Page(comments=[Comment(user=u3, comment="Its very good")])
         p3.save()
 
-        p4 = Page(comments = [Comment(user=u2, comment="Heavy Metal song")])
+        p4 = Page(comments=[Comment(user=u2, comment="Heavy Metal song")])
         p4.save()
 
         self.assertEqual([p1, p2], list(Page.objects.filter(comments__user=u1)))
-        self.assertEqual([p1, p2, p4], list(Page.objects.filter(comments__user=u2)))
+        self.assertEqual(
+            [p1, p2, p4],
+            list(Page.objects.filter(comments__user=u2)))
         self.assertEqual([p1, p3], list(Page.objects.filter(comments__user=u3)))
 
     def test_save_embedded_document(self):
@@ -1689,7 +1772,6 @@ class DocumentTest(unittest.TestCase):
 
         class Site(Document):
             page = EmbeddedDocumentField(Page)
-
 
         Site.drop_collection()
         site = Site(page=Page(log_message="Warning: Dummy message"))
@@ -1842,7 +1924,7 @@ class DocumentTest(unittest.TestCase):
         reviewer = self.Person(name='Re Viewer')
         reviewer.save()
 
-        post = BlogPost(content = 'Watched some TV')
+        post = BlogPost(content='Watched some TV')
         post.author = author
         post.reviewer = reviewer
         post.save()
@@ -1873,7 +1955,7 @@ class DocumentTest(unittest.TestCase):
         reviewer = self.Person(name='Re Viewer')
         reviewer.save()
 
-        post = BlogPost(content= 'Watched some TV')
+        post = BlogPost(content='Watched some TV')
         post.authors = [author]
         post.reviewers = [reviewer]
         post.save()
@@ -1901,7 +1983,8 @@ class DocumentTest(unittest.TestCase):
                 father = ReferenceField('Person', reverse_delete_rule=DENY)
                 mother = ReferenceField('Person', reverse_delete_rule=DENY)
 
-        self.assertRaises(InvalidDocumentError, throw_invalid_document_error_embedded)
+        self.assertRaises(InvalidDocumentError,
+                          throw_invalid_document_error_embedded)
 
     def test_reverse_delete_rule_cascade_recurs(self):
         """Ensure that a chain of documents is also deleted upon cascaded
@@ -1923,11 +2006,11 @@ class DocumentTest(unittest.TestCase):
         author = self.Person(name='Test User')
         author.save()
 
-        post = BlogPost(content = 'Watched some TV')
+        post = BlogPost(content='Watched some TV')
         post.author = author
         post.save()
 
-        comment = Comment(text = 'Kudos.')
+        comment = Comment(text='Kudos.')
         comment.post = post
         comment.save()
 
@@ -1955,7 +2038,7 @@ class DocumentTest(unittest.TestCase):
         author = self.Person(name='Test User')
         author.save()
 
-        post = BlogPost(content = 'Watched some TV')
+        post = BlogPost(content='Watched some TV')
         post.author = author
         post.save()
 
@@ -2011,7 +2094,7 @@ class DocumentTest(unittest.TestCase):
         u1 = User.objects.create()
         u2 = User.objects.create()
         u3 = User.objects.create()
-        u4 = User() # New object
+        u4 = User()  # New object
 
         b1 = BlogPost.objects.create()
         b2 = BlogPost.objects.create()
@@ -2022,26 +2105,26 @@ class DocumentTest(unittest.TestCase):
         self.assertTrue(u1 in all_user_list)
         self.assertTrue(u2 in all_user_list)
         self.assertTrue(u3 in all_user_list)
-        self.assertFalse(u4 in all_user_list) # New object
-        self.assertFalse(b1 in all_user_list) # Other object
-        self.assertFalse(b2 in all_user_list) # Other object
+        self.assertFalse(u4 in all_user_list)  # New object
+        self.assertFalse(b1 in all_user_list)  # Other object
+        self.assertFalse(b2 in all_user_list)  # Other object
 
         # in Dict
         all_user_dic = {}
         for u in User.objects.all():
             all_user_dic[u] = "OK"
 
-        self.assertEqual(all_user_dic.get(u1, False), "OK" )
-        self.assertEqual(all_user_dic.get(u2, False), "OK" )
-        self.assertEqual(all_user_dic.get(u3, False), "OK" )
-        self.assertEqual(all_user_dic.get(u4, False), False ) # New object
-        self.assertEqual(all_user_dic.get(b1, False), False ) # Other object
-        self.assertEqual(all_user_dic.get(b2, False), False ) # Other object
+        self.assertEqual(all_user_dic.get(u1, False), "OK")
+        self.assertEqual(all_user_dic.get(u2, False), "OK")
+        self.assertEqual(all_user_dic.get(u3, False), "OK")
+        self.assertEqual(all_user_dic.get(u4, False), False)  # New object
+        self.assertEqual(all_user_dic.get(b1, False), False)  # Other object
+        self.assertEqual(all_user_dic.get(b2, False), False)  # Other object
 
         # in Set
         all_user_set = set(User.objects.all())
 
-        self.assertTrue(u1 in all_user_set )
+        self.assertTrue(u1 in all_user_set)
 
     def test_picklable(self):
 
@@ -2113,7 +2196,6 @@ class DocumentTest(unittest.TestCase):
         d.save()
 
         self.assertEquals(Doc.objects(archived=False).count(), 1)
-
 
     def test_can_save_false_values_dynamic(self):
         """Ensures you can save False values on dynamic docs"""
@@ -2211,9 +2293,12 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(AuthorBooks._get_db(), get_db("testdb-3"))
 
         # Collections
-        self.assertEqual(User._get_collection(), get_db("testdb-1")[User._get_collection_name()])
-        self.assertEqual(Book._get_collection(), get_db("testdb-2")[Book._get_collection_name()])
-        self.assertEqual(AuthorBooks._get_collection(), get_db("testdb-3")[AuthorBooks._get_collection_name()])
+        self.assertEqual(User._get_collection(),
+                         get_db("testdb-1")[User._get_collection_name()])
+        self.assertEqual(Book._get_collection(),
+                         get_db("testdb-2")[Book._get_collection_name()])
+        self.assertEqual(AuthorBooks._get_collection(),
+                         get_db("testdb-3")[AuthorBooks._get_collection_name()])
 
     def test_db_ref_usage(self):
         """ DB Ref usage in __raw__ queries """
@@ -2249,9 +2334,18 @@ class DocumentTest(unittest.TestCase):
         peter = User.objects.create(name="Peter")
 
         # Bob
-        Book.objects.create(name="1", author=bob, extra={"a": bob.to_dbref(), "b": [karl.to_dbref(), susan.to_dbref()]})
-        Book.objects.create(name="2", author=bob, extra={"a": bob.to_dbref(), "b": karl.to_dbref()} )
-        Book.objects.create(name="3", author=bob, extra={"a": bob.to_dbref(), "c": [jon.to_dbref(), peter.to_dbref()]})
+        Book.objects.create(name="1",
+                            author=bob,
+                            extra={"a": bob.to_dbref(),
+                                   "b": [karl.to_dbref(), susan.to_dbref()]})
+        Book.objects.create(name="2",
+                            author=bob,
+                            extra={"a": bob.to_dbref(),
+                                   "b": karl.to_dbref()})
+        Book.objects.create(name="3",
+                            author=bob,
+                            extra={"a": bob.to_dbref(),
+                                   "c": [jon.to_dbref(), peter.to_dbref()]})
         Book.objects.create(name="4", author=bob)
 
         # Jon
@@ -2262,13 +2356,16 @@ class DocumentTest(unittest.TestCase):
         Book.objects.create(name="9", author=jon, extra={"a": peter.to_dbref()})
 
         # Checks
-        self.assertEqual(u",".join([str(b) for b in Book.objects.all()] ) , "1,2,3,4,5,6,7,8,9" )
+        self.assertEqual(
+            u",".join([str(b) for b in Book.objects.all()]),
+            "1,2,3,4,5,6,7,8,9")
         # bob related books
-        self.assertEqual(u",".join([str(b) for b in Book.objects.filter(
-                                    Q(extra__a=bob ) |
-                                    Q(author=bob) |
-                                    Q(extra__b=bob))]) ,
-                                    "1,2,3,4")
+        self.assertEqual(
+            u",".join([str(b) for b in
+                       Book.objects.filter(Q(extra__a=bob) |
+                                           Q(author=bob) |
+                                           Q(extra__b=bob))]) ,
+            "1,2,3,4")
 
         # Susan & Karl related books
         self.assertEqual(u",".join([str(b) for b in Book.objects.filter(
@@ -2278,15 +2375,14 @@ class DocumentTest(unittest.TestCase):
                                     ) ] ) , "1" )
 
         # $Where
-        self.assertEqual(u",".join([str(b) for b in Book.objects.filter(
-                                    __raw__={
-                                        "$where": """
-                                            function(){
-                                                return this.name == '1' ||
-                                                       this.name == '2';}"""
-                                        }
-                                    ) ]), "1,2")
-
+        self.assertEqual(
+            u",".join([str(b) for b in
+                       Book.objects.filter(
+                           __raw__={"$where": """
+                                        function(){
+                                            return this.name == '1' ||
+                                                   this.name == '2';}"""})]),
+            "1,2")
 
     def test_document_equality(self):
         class A(Document):

--- a/tests/document.py
+++ b/tests/document.py
@@ -2492,12 +2492,17 @@ class ShardedDocumentTest(unittest.TestCase):
             age = IntField()
 
             meta = {'allow_inheritance': True,
-                    'shard_key': ('region',)}
+                    'shard_key': ('region', '_id',)}
+        self.allow_tablescans(ShardedPerson)
         self.ensure_sharded(ShardedPerson)
         self.ShardedPerson = ShardedPerson
 
     def tearDown(self):
         self.ShardedPerson.drop_collection()
+
+    def allow_tablescans(self, model):
+        model.objects._collection.ensure_index([('_cls', pymongo.ASCENDING)],
+                                               background=True)
 
     def ensure_sharded(self, model):
         """

--- a/tests/document.py
+++ b/tests/document.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import pickle
 import pymongo
+import six
 import bson
 import unittest
 import warnings
@@ -2560,6 +2561,7 @@ class DocumentTest(unittest.TestCase):
         class User(Document):
             name = StringField()
 
+        @six.python_2_unicode_compatible
         class Book(Document):
             name = StringField()
             author = ReferenceField(User)
@@ -2567,9 +2569,6 @@ class DocumentTest(unittest.TestCase):
             meta = {
                 'ordering': ['+name']
             }
-
-            def __unicode__(self):
-                return self.name
 
             def __str__(self):
                 return self.name
@@ -2611,33 +2610,34 @@ class DocumentTest(unittest.TestCase):
 
         # Checks
         self.assertEqual(
-            u",".join([str(b) for b in Book.objects.all()]),
-            "1,2,3,4,5,6,7,8,9")
+            u','.join([six.text_type(b) for b in Book.objects.all()]),
+            u'1,2,3,4,5,6,7,8,9')
         # bob related books
         self.assertEqual(
-            u",".join([str(b) for b in
-                       Book.objects.filter(Q(extra__a=bob) |
-                                           Q(author=bob) |
-                                           Q(extra__b=bob))]),
-            "1,2,3,4")
+            u','.join([six.text_type(b) for b in
+                Book.objects.filter(Q(extra__a=bob) |
+                                    Q(author=bob) |
+                                    Q(extra__b=bob))]),
+            u'1,2,3,4')
 
         # Susan & Karl related books
         self.assertEqual(
-            u",".join([str(b) for b in Book.objects.filter(
-                        Q(extra__a__all=[karl, susan]) |
-                        Q(author__all=[karl, susan]) |
-                        Q(extra__b__all=[karl.to_dbref(), susan.to_dbref()]))]),
-            "1")
+            u','.join([six.text_type(b) for b in
+                Book.objects.filter(Q(extra__a__all=[karl, susan]) |
+                                    Q(author__all=[karl, susan]) |
+                                    Q(extra__b__all=[
+                                        karl.to_dbref(), susan.to_dbref()]))]),
+            u'1')
 
         # $Where
         self.assertEqual(
-            u",".join([str(b) for b in
+            ','.join([six.text_type(b) for b in
                        Book.objects.filter(
-                           __raw__={"$where": """
+                           __raw__={'$where': """
                                         function(){
                                             return this.name == '1' ||
                                                    this.name == '2';}"""})]),
-            "1,2")
+            '1,2')
 
     def test_document_equality(self):
         class A(Document):

--- a/tests/document.py
+++ b/tests/document.py
@@ -2593,13 +2593,18 @@ class ShardedDocumentTest(unittest.TestCase):
 
     def test_fails_to_create_sharded_doc_without_shard_key(self):
         person = self.ShardedPerson(name='jandres')
-        with self.assertRaises(OperationError):
+        with self.assertRaises(OperationError) as cm:
             person.save()
+        self.assertIn('does not contain shard key', str(cm.exception))
 
     def test_reload_sharded(self):
         """Duplicate of test above with an actually sharded collection"""
         author = self.ShardedPerson(region='eu', name='dcrosta')
         author.save()
+        author.reload()
+        # Sanity check that reload doesn't leave debris thereby blocking a
+        # subsequent reload. We have no proof this would be the case, it's
+        # just the usual paranoia.
         author.reload()
 
     def test_abstract_document_with_shard_key(self):
@@ -2622,8 +2627,6 @@ class ShardedDocumentTest(unittest.TestCase):
 
         p1 = self.ShardedPerson.objects.first()
         self.assertEquals(p1.name, author.name)
-
-        self.ShardedPerson.drop_collection()
 
     def test_sharded_document_delete(self):
         """Ensure that document may be deleted using the delete method."""

--- a/tests/document.py
+++ b/tests/document.py
@@ -2479,6 +2479,21 @@ class DocumentTest(unittest.TestCase):
         self.assertTrue(a != b)
         self.assertTrue(a != somethingElse)
 
+    def test_abstract_document_with_shard_key(self):
+        class AbstractShardedDocument(Document):
+            meta = {'abstract': True,
+                    'shard_key': ('shard',)}
+            shard = StringField(required=True)
+
+        class Animal(AbstractShardedDocument):
+            name = StringField(required=True)
+
+        a = Animal(shard='eu', name='Kenneth')
+        a.save()
+
+        b = Animal(name='No shard specified!')
+        with self.assertRaises(ValidationError):
+            b.save()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/document.py
+++ b/tests/document.py
@@ -302,7 +302,7 @@ class DocumentTest(unittest.TestCase):
 
         list_stats = []
 
-        for i in xrange(10):
+        for _ in range(10):
             s = Stats()
             s.save()
             list_stats.append(s)
@@ -531,7 +531,7 @@ class DocumentTest(unittest.TestCase):
         Log.drop_collection()
 
         # Ensure that the collection handles up to its maximum
-        for i in range(10):
+        for _ in range(10):
             Log().save()
 
         self.assertEqual(len(Log.objects), 10)
@@ -566,8 +566,8 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
         BlogPost.objects._collection.ensure_index([('tags', pymongo.ASCENDING)])
 
-        for i in xrange(0, 10):
-            tags = [("tag %i" % n) for n in xrange(0, i % 2)]
+        for i in range(0, 10):
+            tags = [("tag %i" % n) for n in range(0, i % 2)]
             BlogPost(tags=tags).save()
 
         self.assertEquals(BlogPost.objects.count(), 10)
@@ -588,8 +588,8 @@ class DocumentTest(unittest.TestCase):
         BlogPost.drop_collection()
         BlogPost.objects._collection.ensure_index([('tags', pymongo.ASCENDING)])
 
-        for i in xrange(0, 10):
-            tags = [("tag %i" % n) for n in xrange(0, i % 2)]
+        for i in range(0, 10):
+            tags = [("tag %i" % n) for n in range(0, i % 2)]
             BlogPost(tags=tags).save()
 
         with self.assertRaises(pymongo.errors.OperationFailure):

--- a/tests/document.py
+++ b/tests/document.py
@@ -47,7 +47,7 @@ class DocumentTest(unittest.TestCase):
         """Add FutureWarning for future allow_inhertiance default change.
         """
 
-        with warnings.catch_warnings(True) as errors:
+        with warnings.catch_warnings(record=True) as errors:
 
             class SimpleBase(Document):
                 a = IntField()
@@ -59,7 +59,7 @@ class DocumentTest(unittest.TestCase):
             self.assertEqual(len(errors), 1)
             warning = errors[0]
             self.assertEqual(FutureWarning, warning.category)
-            self.assertTrue("InheritedClass" in warning.message.message)
+            self.assertTrue('InheritedClass' in str(warning.message))
 
     def test_drop_collection(self):
         """Ensure that the collection may be dropped from the database.

--- a/tests/document.py
+++ b/tests/document.py
@@ -3,6 +3,7 @@ import pymongo
 import bson
 import unittest
 import warnings
+from distutils.version import StrictVersion
 
 from datetime import datetime
 
@@ -474,7 +475,7 @@ class DocumentTest(unittest.TestCase):
             date = DateTimeField(default=datetime.now)
             meta = {
                 'max_documents': 10,
-                'max_size': 90000,
+                'max_size': 25600,
             }
 
         Log.drop_collection()
@@ -492,7 +493,7 @@ class DocumentTest(unittest.TestCase):
         options = Log.objects._collection.options()
         self.assertEqual(options['capped'], True)
         self.assertEqual(options['max'], 10)
-        self.assertEqual(options['size'], 90000)
+        self.assertEqual(options['size'], 25600)  # Must be multiple of 256
 
         # Check that the document cannot be redefined with different options
         def recreate_log_document():
@@ -507,17 +508,13 @@ class DocumentTest(unittest.TestCase):
 
         Log.drop_collection()
 
-    def test_hint(self):
+    def test_can_hint_without_breaking_the_query(self):
 
         class BlogPost(Document):
             tags = ListField(StringField())
-            meta = {
-                'indexes': [
-                    'tags',
-                ],
-            }
 
         BlogPost.drop_collection()
+        BlogPost.objects._collection.ensure_index([('tags', pymongo.ASCENDING)])
 
         for i in xrange(0, 10):
             tags = [("tag %i" % n) for n in xrange(0, i % 2)]
@@ -525,17 +522,28 @@ class DocumentTest(unittest.TestCase):
 
         self.assertEquals(BlogPost.objects.count(), 10)
         self.assertEquals(BlogPost.objects.hint().count(), 10)
-        self.assertEquals(BlogPost.objects.hint([('tags', 1)]).count(), 10)
+        self.assertEquals(
+            BlogPost.objects.hint([('tags', pymongo.ASCENDING)]).count(),
+            10)
 
-        self.assertEquals(BlogPost.objects.hint([('ZZ', 1)]).count(), 10)
+    def test_hint_without_index_will_raise_if_mongo3(self):
+        connection = pymongo.MongoClient()
+        mongo_version = connection.server_info()['version']
+        if StrictVersion(mongo_version) < StrictVersion('3.0'):
+            return
 
-        def invalid_index():
-            list(BlogPost.objects.hint('tags'))
-        self.assertRaises(pymongo.errors.OperationFailure, invalid_index)
+        class BlogPost(Document):
+            tags = ListField(StringField())
 
-        def invalid_index_2():
-            return list(BlogPost.objects.hint([('tags', 1)]))
-        self.assertRaises(pymongo.errors.OperationFailure, invalid_index_2)
+        BlogPost.drop_collection()
+        BlogPost.objects._collection.ensure_index([('tags', pymongo.ASCENDING)])
+
+        for i in xrange(0, 10):
+            tags = [("tag %i" % n) for n in xrange(0, i % 2)]
+            BlogPost(tags=tags).save()
+
+        with self.assertRaises(pymongo.errors.OperationFailure):
+            self.assertEquals(BlogPost.objects.hint([('ZZ', 1)]).count(), 10)
 
     def test_custom_id_field(self):
         """Ensure that documents may be created with custom primary keys.

--- a/tests/document.py
+++ b/tests/document.py
@@ -701,6 +701,17 @@ class DocumentTest(unittest.TestCase):
         self.assertEqual(person.name, "Mr Test User")
         self.assertEqual(person.age, 21)
 
+    def test_reload_sharded(self):
+        class Animal(Document):
+            superphylum = StringField()
+            meta = {'shard_key': ('superphylum',)}
+
+        Animal.drop_collection()
+        doc = Animal(superphylum = 'Deuterostomia')
+        doc.save()
+        doc.reload()
+        Animal.drop_collection()
+
     def test_reload_referencing(self):
         """Ensures reloading updates weakrefs correctly
         """

--- a/tests/document.py
+++ b/tests/document.py
@@ -2279,5 +2279,45 @@ class DocumentTest(unittest.TestCase):
                                         }
                                     ) ]), "1,2")
 
+
+    def test_document_equality(self):
+        class A(Document):
+            name = StringField()
+
+        class B(Document):
+            name = StringField()
+
+        class SomethingElse(object):
+            def __init__(self, id, name):
+                self.id = id
+                self.name = name
+
+        a = A(id=1, name="BOOK")
+        a_ = A(id=1, name="BOOK")
+        b = B(id=1, name="BOOK")
+        somethingElse = SomethingElse(id=1, name="BOOK")
+
+        # ensure __eq__ returns NotImplemented
+        self.assertEqual(a.__eq__(a_), True)
+        self.assertEqual(a.__eq__(b), NotImplemented)
+        self.assertEqual(a.__eq__(somethingElse), NotImplemented)
+
+        # test equality
+        self.assertTrue(a == a_)
+        self.assertFalse(a == b)
+        self.assertFalse(a == somethingElse)
+
+        # test __ne__ returns NotImplemented
+        self.assertEqual(a.__ne__(a_), False)
+        self.assertEqual(a.__ne__(b), NotImplemented)
+        self.assertEqual(a.__ne__(somethingElse), NotImplemented)
+
+        # test not equal
+        self.assertFalse(a != a_)
+        self.assertTrue(a != b)
+        self.assertTrue(a != somethingElse)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/document.py
+++ b/tests/document.py
@@ -56,9 +56,9 @@ class DocumentTest(unittest.TestCase):
                 b = IntField()
 
             InheritedClass()
-            self.assertEquals(len(errors), 1)
+            self.assertEqual(len(errors), 1)
             warning = errors[0]
-            self.assertEquals(FutureWarning, warning.category)
+            self.assertEqual(FutureWarning, warning.category)
             self.assertTrue("InheritedClass" in warning.message.message)
 
     def test_drop_collection(self):
@@ -114,18 +114,18 @@ class DocumentTest(unittest.TestCase):
 
         class DefaultNamingTest(Document):
             pass
-        self.assertEquals('default_naming_test',
+        self.assertEqual('default_naming_test',
                           DefaultNamingTest._get_collection_name())
 
         class CustomNamingTest(Document):
             meta = {'collection': 'pimp_my_collection'}
 
-        self.assertEquals('pimp_my_collection',
+        self.assertEqual('pimp_my_collection',
                           CustomNamingTest._get_collection_name())
 
         class DynamicNamingTest(Document):
             meta = {'collection': lambda c: "DYNAMO"}
-        self.assertEquals('DYNAMO', DynamicNamingTest._get_collection_name())
+        self.assertEqual('DYNAMO', DynamicNamingTest._get_collection_name())
 
         # Use Abstract class to handle backwards compatibility
         class BaseDocument(Document):
@@ -136,12 +136,12 @@ class DocumentTest(unittest.TestCase):
 
         class OldNamingConvention(BaseDocument):
             pass
-        self.assertEquals('oldnamingconvention',
+        self.assertEqual('oldnamingconvention',
                           OldNamingConvention._get_collection_name())
 
         class InheritedAbstractNamingTest(BaseDocument):
             meta = {'collection': 'wibble'}
-        self.assertEquals('wibble',
+        self.assertEqual('wibble',
                           InheritedAbstractNamingTest._get_collection_name())
 
         with warnings.catch_warnings(record=True) as w:
@@ -155,7 +155,7 @@ class DocumentTest(unittest.TestCase):
                 meta = {'collection': 'fail'}
 
             self.assertTrue(issubclass(w[0].category, SyntaxWarning))
-            self.assertEquals('non_abstract_base',
+            self.assertEqual('non_abstract_base',
                               InheritedDocumentFailTest._get_collection_name())
 
         # Mixin tests
@@ -166,7 +166,7 @@ class DocumentTest(unittest.TestCase):
 
         class OldMixinNamingConvention(Document, BaseMixin):
             pass
-        self.assertEquals('oldmixinnamingconvention',
+        self.assertEqual('oldmixinnamingconvention',
                           OldMixinNamingConvention._get_collection_name())
 
         class BaseMixin(object):
@@ -180,7 +180,7 @@ class DocumentTest(unittest.TestCase):
         class MyDocument(BaseDocument):
             pass
 
-        self.assertEquals('basedocument', MyDocument._get_collection_name())
+        self.assertEqual('basedocument', MyDocument._get_collection_name())
 
     def test_get_superclasses(self):
         """Ensure that the correct list of superclasses is assembled.
@@ -243,10 +243,10 @@ class DocumentTest(unittest.TestCase):
         h = Human()
         h.save()
 
-        self.assertEquals(Human.objects.count(), 1)
-        self.assertEquals(Mammal.objects.count(), 1)
-        self.assertEquals(Animal.objects.count(), 1)
-        self.assertEquals(Base.objects.count(), 1)
+        self.assertEqual(Human.objects.count(), 1)
+        self.assertEqual(Mammal.objects.count(), 1)
+        self.assertEqual(Animal.objects.count(), 1)
+        self.assertEqual(Base.objects.count(), 1)
         Base.drop_collection()
 
     def test_polymorphic_queries(self):
@@ -571,9 +571,9 @@ class DocumentTest(unittest.TestCase):
             tags = [("tag %i" % n) for n in range(0, i % 2)]
             BlogPost(tags=tags).save()
 
-        self.assertEquals(BlogPost.objects.count(), 10)
-        self.assertEquals(BlogPost.objects.hint().count(), 10)
-        self.assertEquals(
+        self.assertEqual(BlogPost.objects.count(), 10)
+        self.assertEqual(BlogPost.objects.hint().count(), 10)
+        self.assertEqual(
             BlogPost.objects.hint([('tags', pymongo.ASCENDING)]).count(),
             10)
 
@@ -594,7 +594,7 @@ class DocumentTest(unittest.TestCase):
             BlogPost(tags=tags).save()
 
         with self.assertRaises(pymongo.errors.OperationFailure):
-            self.assertEquals(BlogPost.objects.hint([('ZZ', 1)]).count(), 10)
+            self.assertEqual(BlogPost.objects.hint([('ZZ', 1)]).count(), 10)
 
     def test_custom_id_field(self):
         """Ensure that documents may be created with custom primary keys.
@@ -745,17 +745,17 @@ class DocumentTest(unittest.TestCase):
         doc.embedded_field.list_field.append(1)
         doc.embedded_field.dict_field['woot'] = "woot"
 
-        self.assertEquals(doc._get_changed_fields(), [
+        self.assertEqual(doc._get_changed_fields(), [
             'list_field', 'dict_field', 'embedded_field.list_field',
             'embedded_field.dict_field'])
         doc.save()
 
         doc = doc.reload(10)
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(len(doc.list_field), 4)
-        self.assertEquals(len(doc.dict_field), 2)
-        self.assertEquals(len(doc.embedded_field.list_field), 4)
-        self.assertEquals(len(doc.embedded_field.dict_field), 2)
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(len(doc.list_field), 4)
+        self.assertEqual(len(doc.dict_field), 2)
+        self.assertEqual(len(doc.embedded_field.list_field), 4)
+        self.assertEqual(len(doc.embedded_field.dict_field), 2)
 
     def test_reload_deleted_document_raises_doesnotexist(self):
         person = self.Person(name="Test User", age=20)
@@ -768,16 +768,16 @@ class DocumentTest(unittest.TestCase):
         """Ensure that dictionary-style field access works properly.
         """
         person = self.Person(name='Test User', age=30)
-        self.assertEquals(person['name'], 'Test User')
+        self.assertEqual(person['name'], 'Test User')
 
         self.assertRaises(KeyError, person.__getitem__, 'salary')
         self.assertRaises(KeyError, person.__setitem__, 'salary', 50)
 
         person['name'] = 'Another User'
-        self.assertEquals(person['name'], 'Another User')
+        self.assertEqual(person['name'], 'Another User')
 
         # Length = length(assigned fields + id)
-        self.assertEquals(len(person), 3)
+        self.assertEqual(len(person), 3)
 
         self.assertTrue('age' in person)
         person.age = None
@@ -855,7 +855,7 @@ class DocumentTest(unittest.TestCase):
         user.save()
 
         user.reload()
-        self.assertEquals(user.thing.count, 0)
+        self.assertEqual(user.thing.count, 0)
 
     def test_save_max_recursion_not_hit(self):
 
@@ -904,7 +904,7 @@ class DocumentTest(unittest.TestCase):
         p.save()
 
         p1.reload()
-        self.assertEquals(p1.name, p.parent.name)
+        self.assertEqual(p1.name, p.parent.name)
 
     def test_save_cascade_kwargs(self):
 
@@ -927,7 +927,7 @@ class DocumentTest(unittest.TestCase):
         p.save()
 
         p1.reload()
-        self.assertEquals(p1.name, p.parent.name)
+        self.assertEqual(p1.name, p.parent.name)
 
     def test_save_cascade_meta(self):
 
@@ -952,11 +952,11 @@ class DocumentTest(unittest.TestCase):
         p.save()
 
         p1.reload()
-        self.assertNotEquals(p1.name, p.parent.name)
+        self.assertNotEqual(p1.name, p.parent.name)
 
         p.save(cascade=True)
         p1.reload()
-        self.assertEquals(p1.name, p.parent.name)
+        self.assertEqual(p1.name, p.parent.name)
 
     def test_save_cascades_generically(self):
 
@@ -978,7 +978,7 @@ class DocumentTest(unittest.TestCase):
         p.save()
 
         p1.reload()
-        self.assertEquals(p1.name, p.parent.name)
+        self.assertEqual(p1.name, p.parent.name)
 
     def test_update(self):
         """Ensure that an existing document is updated instead of be overwritten.
@@ -993,7 +993,7 @@ class DocumentTest(unittest.TestCase):
         same_person.save()
 
         # Confirm only one object
-        self.assertEquals(self.Person.objects.count(), 1)
+        self.assertEqual(self.Person.objects.count(), 1)
 
         # reload
         person.reload()
@@ -1079,7 +1079,7 @@ class DocumentTest(unittest.TestCase):
         author.reload()
 
         p1 = self.Person.objects.first()
-        self.assertEquals(p1.name, author.name)
+        self.assertEqual(p1.name, author.name)
 
         def update_no_value_raises():
             person = self.Person.objects.first()
@@ -1156,40 +1156,40 @@ class DocumentTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         doc.string_field = 'hello'
-        self.assertEquals(doc._get_changed_fields(), ['string_field'])
-        self.assertEquals(doc._delta(), ({'string_field': 'hello'}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['string_field'])
+        self.assertEqual(doc._delta(), ({'string_field': 'hello'}, {}))
 
         doc._changed_fields = []
         doc.int_field = 1
-        self.assertEquals(doc._get_changed_fields(), ['int_field'])
-        self.assertEquals(doc._delta(), ({'int_field': 1}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['int_field'])
+        self.assertEqual(doc._delta(), ({'int_field': 1}, {}))
 
         doc._changed_fields = []
         dict_value = {'hello': 'world', 'ping': 'pong'}
         doc.dict_field = dict_value
-        self.assertEquals(doc._get_changed_fields(), ['dict_field'])
-        self.assertEquals(doc._delta(), ({'dict_field': dict_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['dict_field'])
+        self.assertEqual(doc._delta(), ({'dict_field': dict_value}, {}))
 
         doc._changed_fields = []
         list_value = ['1', 2, {'hello': 'world'}]
         doc.list_field = list_value
-        self.assertEquals(doc._get_changed_fields(), ['list_field'])
-        self.assertEquals(doc._delta(), ({'list_field': list_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['list_field'])
+        self.assertEqual(doc._delta(), ({'list_field': list_value}, {}))
 
         # Test unsetting
         doc._changed_fields = []
         doc.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['dict_field'])
-        self.assertEquals(doc._delta(), ({}, {'dict_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['dict_field'])
+        self.assertEqual(doc._delta(), ({}, {'dict_field': 1}))
 
         doc._changed_fields = []
         doc.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['list_field'])
-        self.assertEquals(doc._delta(), ({}, {'list_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['list_field'])
+        self.assertEqual(doc._delta(), ({}, {'list_field': 1}))
 
     def test_delta_recursive(self):
 
@@ -1211,8 +1211,8 @@ class DocumentTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         embedded_1 = Embedded()
         embedded_1.string_field = 'hello'
@@ -1221,7 +1221,7 @@ class DocumentTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, {'hello': 'world'}]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field'])
+        self.assertEqual(doc._get_changed_fields(), ['embedded_field'])
 
         embedded_delta = {
             'string_field': 'hello',
@@ -1229,33 +1229,33 @@ class DocumentTest(unittest.TestCase):
             'dict_field': {'hello': 'world'},
             'list_field': ['1', 2, {'hello': 'world'}]
         }
-        self.assertEquals(doc.embedded_field._delta(), (embedded_delta, {}))
+        self.assertEqual(doc.embedded_field._delta(), (embedded_delta, {}))
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(),
+        self.assertEqual(doc._delta(),
                           ({'embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.dict_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
+        self.assertEqual(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
+        self.assertEqual(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.dict_field, {})
+        self.assertEqual(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'list_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field': 1}))
+        self.assertEqual(doc.embedded_field._delta(), ({}, {'list_field': 1}))
+        self.assertEqual(doc._delta(), ({}, {'embedded_field.list_field': 1}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field, [])
+        self.assertEqual(doc.embedded_field.list_field, [])
 
         embedded_2 = Embedded()
         embedded_2.string_field = 'hello'
@@ -1264,9 +1264,9 @@ class DocumentTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
+        self.assertEqual(doc.embedded_field._delta(), ({
             'list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'string_field': 'hello',
@@ -1276,7 +1276,7 @@ class DocumentTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field': [
                 '1',
@@ -1290,35 +1290,35 @@ class DocumentTest(unittest.TestCase):
         doc.save()
         doc = doc.reload(10)
 
-        self.assertEquals(doc.embedded_field.list_field[0], '1')
-        self.assertEquals(doc.embedded_field.list_field[1], 2)
+        self.assertEqual(doc.embedded_field.list_field[0], '1')
+        self.assertEqual(doc.embedded_field.list_field[1], 2)
         # TODO COLIN: Fix? !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         return
         for k in doc.embedded_field.list_field[2]._fields:
-            self.assertEquals(doc.embedded_field.list_field[2][k],
+            self.assertEqual(doc.embedded_field.list_field[2][k],
                               embedded_2[k])
 
         doc.embedded_field.list_field[2].string_field = 'world'
-        self.assertEquals(
+        self.assertEqual(
             doc._get_changed_fields(),
             ['embedded_field.list_field.2.string_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'list_field.2.string_field': 'world'}, {}))
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.string_field': 'world'}, {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'world')
 
         # Test multiple assignments
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'list_field': [
                 '1',
@@ -1329,7 +1329,7 @@ class DocumentTest(unittest.TestCase):
                  'list_field': ['1', 2, {'hello': 'world'}],
                  'dict_field': {'hello': 'world'}}]},
              {}))
-        self.assertEquals(doc._delta(), ({
+        self.assertEqual(doc._delta(), ({
             'embedded_field.list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'string_field': 'hello world',
@@ -1339,12 +1339,12 @@ class DocumentTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [2,
                                                          {'hello': 'world'}]},
@@ -1353,7 +1353,7 @@ class DocumentTest(unittest.TestCase):
         doc = doc.reload(10)
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [2,
                                                          {'hello': 'world'},
@@ -1361,26 +1361,26 @@ class DocumentTest(unittest.TestCase):
              {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field.list_field[2].list_field,
             [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field.list_field[2].list_field,
             [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [1, 2, {}]}, {}))
         doc.save()
         doc = doc.reload(10)
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({}, {'embedded_field.list_field.2.list_field': 1}))
 
@@ -1392,10 +1392,10 @@ class DocumentTest(unittest.TestCase):
         doc = doc.reload(10)
 
         doc.dict_field['Embedded'].string_field = 'Hello World'
-        self.assertEquals(
+        self.assertEqual(
             doc._get_changed_fields(),
             ['dict_field.Embedded.string_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'dict_field.Embedded.string_field': 'Hello World'}, {}))
 
@@ -1412,40 +1412,40 @@ class DocumentTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         doc.string_field = 'hello'
-        self.assertEquals(doc._get_changed_fields(), ['db_string_field'])
-        self.assertEquals(doc._delta(), ({'db_string_field': 'hello'}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['db_string_field'])
+        self.assertEqual(doc._delta(), ({'db_string_field': 'hello'}, {}))
 
         doc._changed_fields = []
         doc.int_field = 1
-        self.assertEquals(doc._get_changed_fields(), ['db_int_field'])
-        self.assertEquals(doc._delta(), ({'db_int_field': 1}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['db_int_field'])
+        self.assertEqual(doc._delta(), ({'db_int_field': 1}, {}))
 
         doc._changed_fields = []
         dict_value = {'hello': 'world', 'ping': 'pong'}
         doc.dict_field = dict_value
-        self.assertEquals(doc._get_changed_fields(), ['db_dict_field'])
-        self.assertEquals(doc._delta(), ({'db_dict_field': dict_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['db_dict_field'])
+        self.assertEqual(doc._delta(), ({'db_dict_field': dict_value}, {}))
 
         doc._changed_fields = []
         list_value = ['1', 2, {'hello': 'world'}]
         doc.list_field = list_value
-        self.assertEquals(doc._get_changed_fields(), ['db_list_field'])
-        self.assertEquals(doc._delta(), ({'db_list_field': list_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['db_list_field'])
+        self.assertEqual(doc._delta(), ({'db_list_field': list_value}, {}))
 
         # Test unsetting
         doc._changed_fields = []
         doc.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['db_dict_field'])
-        self.assertEquals(doc._delta(), ({}, {'db_dict_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['db_dict_field'])
+        self.assertEqual(doc._delta(), ({}, {'db_dict_field': 1}))
 
         doc._changed_fields = []
         doc.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['db_list_field'])
-        self.assertEquals(doc._delta(), ({}, {'db_list_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['db_list_field'])
+        self.assertEqual(doc._delta(), ({}, {'db_list_field': 1}))
 
         # Test it saves that data
         doc = Doc()
@@ -1458,10 +1458,10 @@ class DocumentTest(unittest.TestCase):
         doc.save()
         doc = doc.reload(10)
 
-        self.assertEquals(doc.string_field, 'hello')
-        self.assertEquals(doc.int_field, 1)
-        self.assertEquals(doc.dict_field, {'hello': 'world'})
-        self.assertEquals(doc.list_field, ['1', 2, {'hello': 'world'}])
+        self.assertEqual(doc.string_field, 'hello')
+        self.assertEqual(doc.int_field, 1)
+        self.assertEqual(doc.dict_field, {'hello': 'world'})
+        self.assertEqual(doc.list_field, ['1', 2, {'hello': 'world'}])
 
     def test_delta_recursive_db_field(self):
 
@@ -1484,8 +1484,8 @@ class DocumentTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         embedded_1 = Embedded()
         embedded_1.string_field = 'hello'
@@ -1494,7 +1494,7 @@ class DocumentTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, {'hello': 'world'}]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(doc._get_changed_fields(), ['db_embedded_field'])
+        self.assertEqual(doc._get_changed_fields(), ['db_embedded_field'])
 
         embedded_delta = {
             'db_string_field': 'hello',
@@ -1502,37 +1502,37 @@ class DocumentTest(unittest.TestCase):
             'db_dict_field': {'hello': 'world'},
             'db_list_field': ['1', 2, {'hello': 'world'}]
         }
-        self.assertEquals(doc.embedded_field._delta(), (embedded_delta, {}))
+        self.assertEqual(doc.embedded_field._delta(), (embedded_delta, {}))
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(),
+        self.assertEqual(doc._delta(),
                           ({'db_embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc = doc.reload(10)
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['db_embedded_field.db_dict_field'])
-        self.assertEquals(doc.embedded_field._delta(),
+        self.assertEqual(doc.embedded_field._delta(),
                           ({}, {'db_dict_field': 1}))
-        self.assertEquals(doc._delta(),
+        self.assertEqual(doc._delta(),
                           ({}, {'db_embedded_field.db_dict_field': 1}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.dict_field, {})
+        self.assertEqual(doc.embedded_field.dict_field, {})
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['db_embedded_field.db_list_field'])
-        self.assertEquals(doc.embedded_field._delta(),
+        self.assertEqual(doc.embedded_field._delta(),
                           ({}, {'db_list_field': 1}))
-        self.assertEquals(doc._delta(),
+        self.assertEqual(doc._delta(),
                           ({}, {'db_embedded_field.db_list_field': 1}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field, [])
+        self.assertEqual(doc.embedded_field.list_field, [])
 
         embedded_2 = Embedded()
         embedded_2.string_field = 'hello'
@@ -1541,9 +1541,9 @@ class DocumentTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['db_embedded_field.db_list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
+        self.assertEqual(doc.embedded_field._delta(), ({
             'db_list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'db_string_field': 'hello',
@@ -1553,7 +1553,7 @@ class DocumentTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'db_embedded_field.db_list_field': [
                 '1',
@@ -1567,32 +1567,32 @@ class DocumentTest(unittest.TestCase):
         doc.save()
         doc = doc.reload(10)
 
-        self.assertEquals(doc.embedded_field.list_field[0], '1')
-        self.assertEquals(doc.embedded_field.list_field[1], 2)
+        self.assertEqual(doc.embedded_field.list_field[0], '1')
+        self.assertEqual(doc.embedded_field.list_field[1], 2)
 
         return  # Colin style
         doc.embedded_field.list_field[2]['string_field'] = 'world'
-        self.assertEquals(
+        self.assertEqual(
             doc._get_changed_fields(),
             ['db_embedded_field.db_list_field.2.db_string_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'db_list_field.2.db_string_field': 'world'}, {}))
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'db_embedded_field.db_list_field.2.db_string_field': 'world'},
              {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'world')
 
         # Test multiple assignments
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['db_embedded_field.db_list_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'db_list_field': [
                 '1',
@@ -1603,7 +1603,7 @@ class DocumentTest(unittest.TestCase):
                  'db_list_field': ['1', 2, {'hello': 'world'}],
                  'db_dict_field': {'hello': 'world'}}]},
              {}))
-        self.assertEquals(doc._delta(), ({
+        self.assertEqual(doc._delta(), ({
             'db_embedded_field.db_list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'db_string_field': 'hello world',
@@ -1613,12 +1613,12 @@ class DocumentTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'db_embedded_field.db_list_field.2.db_list_field': [
                 2,
@@ -1628,7 +1628,7 @@ class DocumentTest(unittest.TestCase):
         doc = doc.reload(10)
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'db_embedded_field.db_list_field.2.db_list_field': [
                 2,
@@ -1637,17 +1637,17 @@ class DocumentTest(unittest.TestCase):
              {}))
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+        self.assertEqual(doc.embedded_field.list_field[2].list_field,
                           [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc = doc.reload(10)
-        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+        self.assertEqual(doc.embedded_field.list_field[2].list_field,
                           [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'db_embedded_field.db_list_field.2.db_list_field': [1, 2, {}]},
              {}))
@@ -1655,7 +1655,7 @@ class DocumentTest(unittest.TestCase):
         doc = doc.reload(10)
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({}, {'db_embedded_field.db_list_field.2.db_list_field': 1}))
 
@@ -1684,9 +1684,9 @@ class DocumentTest(unittest.TestCase):
         same_person.save()
 
         person = self.Person.objects.get()
-        self.assertEquals(person.name, 'User')
-        self.assertEquals(person.age, 21)
-        self.assertEquals(person.active, False)
+        self.assertEqual(person.name, 'User')
+        self.assertEqual(person.age, 21)
+        self.assertEqual(person.active, False)
 
     def test_delete(self):
         """Ensure that document may be deleted using the delete method.
@@ -1902,10 +1902,10 @@ class DocumentTest(unittest.TestCase):
 
         t = TestDoc.objects.first()
 
-        self.assertEquals(t.age, 19)
-        self.assertEquals(t.comment, "great!")
-        self.assertEquals(t.data, "test")
-        self.assertEquals(t.count, 12)
+        self.assertEqual(t.age, 19)
+        self.assertEqual(t.comment, "great!")
+        self.assertEqual(t.data, "test")
+        self.assertEqual(t.count, 12)
 
     def test_save_reference(self):
         """Ensure that a document reference field may be saved in the database.
@@ -2328,8 +2328,8 @@ class DocumentTest(unittest.TestCase):
         A().save()
         B(foo=True).save()
 
-        self.assertEquals(A.objects.count(), 2)
-        self.assertEquals(B.objects.count(), 1)
+        self.assertEqual(A.objects.count(), 2)
+        self.assertEqual(B.objects.count(), 1)
         A.drop_collection()
         B.drop_collection()
 
@@ -2390,13 +2390,13 @@ class DocumentTest(unittest.TestCase):
         pickled_doc = pickle.dumps(pickle_doc)
         resurrected = pickle.loads(pickled_doc)
 
-        self.assertEquals(resurrected, pickle_doc)
+        self.assertEqual(resurrected, pickle_doc)
 
         resurrected.string = "Two"
         resurrected.save()
 
         pickle_doc = pickle_doc.reload()
-        self.assertEquals(resurrected, pickle_doc)
+        self.assertEqual(resurrected, pickle_doc)
 
     def test_throw_invalid_document_error(self):
 
@@ -2419,7 +2419,7 @@ class DocumentTest(unittest.TestCase):
         a = A()
         a.save()
         a.reload()
-        self.assertEquals(a.b.field1, 'field1')
+        self.assertEqual(a.b.field1, 'field1')
 
         class C(EmbeddedDocument):
             c_field = StringField(default='cfield')
@@ -2436,7 +2436,7 @@ class DocumentTest(unittest.TestCase):
         a.save()
 
         a.reload()
-        self.assertEquals(a.b.field2.c_field, 'new value')
+        self.assertEqual(a.b.field2.c_field, 'new value')
 
     def test_can_save_false_values(self):
         """Ensures you can save False values on save"""
@@ -2450,7 +2450,7 @@ class DocumentTest(unittest.TestCase):
         d.archived = False
         d.save()
 
-        self.assertEquals(Doc.objects(archived=False).count(), 1)
+        self.assertEqual(Doc.objects(archived=False).count(), 1)
 
     def test_can_save_false_values_dynamic(self):
         """Ensures you can save False values on dynamic docs"""
@@ -2463,7 +2463,7 @@ class DocumentTest(unittest.TestCase):
         d.archived = False
         d.save()
 
-        self.assertEquals(Doc.objects(archived=False).count(), 1)
+        self.assertEqual(Doc.objects(archived=False).count(), 1)
 
     def test_do_not_save_unchanged_references(self):
         """Ensures cascading saves dont auto update"""
@@ -2823,7 +2823,7 @@ class ShardedDocumentTest(unittest.TestCase):
         author.reload()
 
         p1 = self.ShardedPerson.objects.first()
-        self.assertEquals(p1.name, author.name)
+        self.assertEqual(p1.name, author.name)
 
     def test_sharded_document_delete(self):
         """Ensure that document may be deleted using the delete method."""

--- a/tests/document.py
+++ b/tests/document.py
@@ -7,7 +7,7 @@ from distutils.version import StrictVersion
 
 from datetime import datetime
 
-from fixtures import Base, PickleEmbedded, PickleTest
+from .fixtures import Base, PickleEmbedded, PickleTest
 
 from mongoengine import (
     connect, Q, CASCADE, NULLIFY, DENY,

--- a/tests/dynamic_document.py
+++ b/tests/dynamic_document.py
@@ -26,12 +26,11 @@ class DynamicDocTest(unittest.TestCase):
         p.name = "James"
         p.age = 34
 
-        self.assertEquals(p.to_mongo(),
-            {"_cls": "Person", "name": "James", "age": 34}
-        )
+        self.assertEquals(
+            p.to_mongo(),
+            {"_cls": "Person", "name": "James", "age": 34})
 
         p.save()
-
         self.assertEquals(self.Person.objects.first().age, 34)
 
         # Confirm no changes to self.Person
@@ -40,11 +39,15 @@ class DynamicDocTest(unittest.TestCase):
     def test_dynamic_document_delta(self):
         """Ensures simple dynamic documents can delta correctly"""
         p = self.Person(name="James", age=34)
-        self.assertEquals(p._delta(), ({'age': 34, 'name': 'James', '_cls': 'Person'}, {}))
+        self.assertEquals(
+            p._delta(),
+            ({'age': 34, 'name': 'James', '_cls': 'Person'}, {}))
 
         p.doc = 123
         del(p.doc)
-        self.assertEquals(p._delta(), ({'age': 34, 'name': 'James', '_cls': 'Person'}, {'doc': 1}))
+        self.assertEquals(
+            p._delta(),
+            ({'age': 34, 'name': 'James', '_cls': 'Person'}, {'doc': 1}))
 
     def test_change_scope_of_variable(self):
         """Test changing the scope of a dynamic field has no adverse effects"""
@@ -170,15 +173,15 @@ class DynamicDocTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, {'hello': 'world'}]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(doc.to_mongo(), {"_cls": "Doc",
-            "embedded_field": {
+        self.assertEquals(
+            doc.to_mongo(),
+            {"_cls": "Doc",
+             "embedded_field": {
                 "_cls": "Embedded",
                 "string_field": "hello",
                 "int_field": 1,
                 "dict_field": {"hello": "world"},
-                "list_field": ['1', 2, {'hello': 'world'}]
-            }
-        })
+                "list_field": ['1', 2, {'hello': 'world'}]}})
         doc.save()
 
         doc = Doc.objects.first()
@@ -213,21 +216,21 @@ class DynamicDocTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, embedded_2]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(doc.to_mongo(), {"_cls": "Doc",
-            "embedded_field": {
+        self.assertEquals(
+            doc.to_mongo(),
+            {"_cls": "Doc",
+             "embedded_field": {
                 "_cls": "Embedded",
                 "string_field": "hello",
                 "int_field": 1,
                 "dict_field": {"hello": "world"},
-                "list_field": ['1', 2,
-                    {"_cls": "Embedded",
-                    "string_field": "hello",
-                    "int_field": 1,
-                    "dict_field": {"hello": "world"},
-                    "list_field": ['1', 2, {'hello': 'world'}]}
-                ]
-            }
-        })
+                "list_field": ['1',
+                               2,
+                               {"_cls": "Embedded",
+                                "string_field": "hello",
+                                "int_field": 1,
+                                "dict_field": {"hello": "world"},
+                                "list_field": ['1', 2, {'hello': 'world'}]}]}})
         doc.save()
         doc = Doc.objects.first()
         self.assertEquals(doc.embedded_field.__class__, Embedded)
@@ -243,7 +246,8 @@ class DynamicDocTest(unittest.TestCase):
         self.assertEquals(embedded_field.string_field, "hello")
         self.assertEquals(embedded_field.int_field, 1)
         self.assertEquals(embedded_field.dict_field, {'hello': 'world'})
-        self.assertEquals(embedded_field.list_field, ['1', 2, {'hello': 'world'}])
+        self.assertEquals(embedded_field.list_field,
+                          ['1', 2, {'hello': 'world'}])
 
     def test_delta_for_dynamic_documents(self):
         p = self.Person()
@@ -345,13 +349,15 @@ class DynamicDocTest(unittest.TestCase):
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(), ({'embedded_field': embedded_delta}, {}))
+        self.assertEquals(doc._delta(),
+                          ({'embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc.reload()
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.dict_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.dict_field'])
         self.assertEquals(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
 
         self.assertEquals(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
@@ -359,7 +365,8 @@ class DynamicDocTest(unittest.TestCase):
         doc.reload()
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.list_field'])
         self.assertEquals(doc.embedded_field._delta(), ({}, {'list_field': 1}))
         self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field': 1}))
         doc.save()
@@ -372,7 +379,8 @@ class DynamicDocTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.list_field'])
         self.assertEquals(doc.embedded_field._delta(), ({
             'list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -383,15 +391,17 @@ class DynamicDocTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(doc._delta(), ({
-            'embedded_field.list_field': ['1', 2, {
-                '_cls': 'Embedded',
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field': [
+                '1',
+                2,
+                {'_cls': 'Embedded',
                  'string_field': 'hello',
                  'dict_field': {'hello': 'world'},
                  'int_field': 1,
-                 'list_field': ['1', 2, {'hello': 'world'}],
-            }]
-        }, {}))
+                 'list_field': ['1', 2, {'hello': 'world'}]}]},
+             {}))
         doc.save()
         doc.reload()
 
@@ -399,27 +409,38 @@ class DynamicDocTest(unittest.TestCase):
         self.assertEquals(doc.embedded_field.list_field[0], '1')
         self.assertEquals(doc.embedded_field.list_field[1], 2)
         for k in doc.embedded_field.list_field[2]._fields:
-            self.assertEquals(doc.embedded_field.list_field[2][k], embedded_2[k])
+            self.assertEquals(doc.embedded_field.list_field[2][k],
+                              embedded_2[k])
 
         doc.embedded_field.list_field[2].string_field = 'world'
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field.2.string_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({'list_field.2.string_field': 'world'}, {}))
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.string_field': 'world'}, {}))
+        self.assertEquals(
+            doc._get_changed_fields(),
+            ['embedded_field.list_field.2.string_field'])
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'list_field.2.string_field': 'world'}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.string_field': 'world'}, {}))
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].string_field, 'world')
+        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+                          'world')
 
         # Test multiple assignments
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
-            'list_field': ['1', 2, {
-            '_cls': 'Embedded',
-            'string_field': 'hello world',
-            'int_field': 1,
-            'list_field': ['1', 2, {'hello': 'world'}],
-            'dict_field': {'hello': 'world'}}]}, {}))
+        self.assertEquals(doc._get_changed_fields(),
+                          ['embedded_field.list_field'])
+        self.assertEquals(
+            doc.embedded_field._delta(),
+            ({'list_field': ['1', 2, {
+              '_cls': 'Embedded',
+              'string_field': 'hello world',
+              'int_field': 1,
+              'list_field': ['1', 2, {'hello': 'world'}],
+              'dict_field': {'hello': 'world'}}]},
+             {}))
         self.assertEquals(doc._delta(), ({
             'embedded_field.list_field': ['1', 2, {
                 '_cls': 'Embedded',
@@ -430,32 +451,49 @@ class DynamicDocTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].string_field, 'hello world')
+        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+                          'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [2, {'hello': 'world'}]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.list_field': [2,
+                                                         {'hello': 'world'}]},
+             {}))
         doc.save()
         doc.reload()
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [2, {'hello': 'world'}, 1]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.list_field': [2,
+                                                         {'hello': 'world'},
+                                                         1]},
+             {}))
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [2, {'hello': 'world'}, 1])
+        self.assertEquals(
+            doc.embedded_field.list_field[2].list_field,
+            [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].list_field, [1, 2, {'hello': 'world'}])
+        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+                          [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
-        self.assertEquals(doc._delta(), ({'embedded_field.list_field.2.list_field': [1, 2, {}]}, {}))
+        self.assertEquals(
+            doc._delta(),
+            ({'embedded_field.list_field.2.list_field': [1, 2, {}]}, {}))
         doc.save()
         doc.reload()
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field.2.list_field': 1}))
+        self.assertEquals(
+            doc._delta(),
+            ({}, {'embedded_field.list_field.2.list_field': 1}))
 
         doc.save()
         doc.reload()
@@ -465,10 +503,13 @@ class DynamicDocTest(unittest.TestCase):
         doc.reload()
 
         doc.dict_field['embedded'].string_field = 'Hello World'
-        self.assertEquals(doc._get_changed_fields(), ['dict_field.embedded.string_field'])
-        self.assertEquals(doc._delta(), ({'dict_field.embedded.string_field': 'Hello World'}, {}))
+        self.assertEquals(
+            doc._get_changed_fields(),
+            ['dict_field.embedded.string_field'])
+        self.assertEquals(
+            doc._delta(),
+            ({'dict_field.embedded.string_field': 'Hello World'}, {}))
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/dynamic_document.py
+++ b/tests/dynamic_document.py
@@ -1,6 +1,8 @@
 import unittest
 
-from mongoengine import *
+from mongoengine import (
+    connect, StringField, IntField,
+    DynamicDocument, DynamicEmbeddedDocument)
 from mongoengine.connection import get_db, register_db
 
 
@@ -189,7 +191,8 @@ class DynamicDocTest(unittest.TestCase):
         self.assertEquals(doc.embedded_field.string_field, "hello")
         self.assertEquals(doc.embedded_field.int_field, 1)
         self.assertEquals(doc.embedded_field.dict_field, {'hello': 'world'})
-        self.assertEquals(doc.embedded_field.list_field, ['1', 2, {'hello': 'world'}])
+        self.assertEquals(doc.embedded_field.list_field,
+                          ['1', 2, {'hello': 'world'}])
 
     def test_complex_embedded_documents(self):
         """Test complex dynamic embedded documents setups"""

--- a/tests/dynamic_document.py
+++ b/tests/dynamic_document.py
@@ -468,3 +468,7 @@ class DynamicDocTest(unittest.TestCase):
         self.assertEquals(doc._get_changed_fields(), ['dict_field.embedded.string_field'])
         self.assertEquals(doc._delta(), ({'dict_field.embedded.string_field': 'Hello World'}, {}))
 
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/dynamic_document.py
+++ b/tests/dynamic_document.py
@@ -28,12 +28,12 @@ class DynamicDocTest(unittest.TestCase):
         p.name = "James"
         p.age = 34
 
-        self.assertEquals(
+        self.assertEqual(
             p.to_mongo(),
             {"_cls": "Person", "name": "James", "age": 34})
 
         p.save()
-        self.assertEquals(self.Person.objects.first().age, 34)
+        self.assertEqual(self.Person.objects.first().age, 34)
 
         # Confirm no changes to self.Person
         self.assertFalse(hasattr(self.Person, 'age'))
@@ -41,13 +41,13 @@ class DynamicDocTest(unittest.TestCase):
     def test_dynamic_document_delta(self):
         """Ensures simple dynamic documents can delta correctly"""
         p = self.Person(name="James", age=34)
-        self.assertEquals(
+        self.assertEqual(
             p._delta(),
             ({'age': 34, 'name': 'James', '_cls': 'Person'}, {}))
 
         p.doc = 123
         del(p.doc)
-        self.assertEquals(
+        self.assertEqual(
             p._delta(),
             ({'age': 34, 'name': 'James', '_cls': 'Person'}, {'doc': 1}))
 
@@ -63,7 +63,7 @@ class DynamicDocTest(unittest.TestCase):
         p.save()
 
         p = self.Person.objects.get()
-        self.assertEquals(p.misc, {'hello': 'world'})
+        self.assertEqual(p.misc, {'hello': 'world'})
 
     def test_delete_dynamic_field(self):
         """Test deleting a dynamic field works"""
@@ -78,10 +78,10 @@ class DynamicDocTest(unittest.TestCase):
         p.save()
 
         p = self.Person.objects.get()
-        self.assertEquals(p.misc, {'hello': 'world'})
+        self.assertEqual(p.misc, {'hello': 'world'})
         collection = self.db[self.Person._get_collection_name()]
         obj = collection.find_one()
-        self.assertEquals(sorted(obj.keys()), ['_cls', '_id', 'misc', 'name'])
+        self.assertEqual(sorted(obj.keys()), ['_cls', '_id', 'misc', 'name'])
 
         del(p.misc)
         p.save()
@@ -90,7 +90,7 @@ class DynamicDocTest(unittest.TestCase):
         self.assertFalse(hasattr(p, 'misc'))
 
         obj = collection.find_one()
-        self.assertEquals(sorted(obj.keys()), ['_cls', '_id', 'name'])
+        self.assertEqual(sorted(obj.keys()), ['_cls', '_id', 'name'])
 
     def test_dynamic_document_queries(self):
         """Ensure we can query dynamic fields"""
@@ -99,10 +99,10 @@ class DynamicDocTest(unittest.TestCase):
         p.age = 22
         p.save()
 
-        self.assertEquals(1, self.Person.objects(age=22).count())
+        self.assertEqual(1, self.Person.objects(age=22).count())
         p = self.Person.objects(age=22)
         p = p.get()
-        self.assertEquals(22, p.age)
+        self.assertEqual(22, p.age)
 
     def test_complex_dynamic_document_queries(self):
         class Person(DynamicDocument):
@@ -122,8 +122,8 @@ class DynamicDocTest(unittest.TestCase):
         p2.age = 10
         p2.save()
 
-        self.assertEquals(Person.objects(age__icontains='ten').count(), 2)
-        self.assertEquals(Person.objects(age__gte=10).count(), 1)
+        self.assertEqual(Person.objects(age__icontains='ten').count(), 2)
+        self.assertEqual(Person.objects(age__gte=10).count(), 1)
 
     def test_complex_data_lookups(self):
         """Ensure you can query dynamic document dynamic fields"""
@@ -131,7 +131,7 @@ class DynamicDocTest(unittest.TestCase):
         p.misc = {'hello': 'world'}
         p.save()
 
-        self.assertEquals(1, self.Person.objects(misc__hello='world').count())
+        self.assertEqual(1, self.Person.objects(misc__hello='world').count())
 
     def test_inheritance(self):
         """Ensure that dynamic document plays nice with inheritance"""
@@ -151,8 +151,8 @@ class DynamicDocTest(unittest.TestCase):
         joe_bloggs.age = 20
         joe_bloggs.save()
 
-        self.assertEquals(1, self.Person.objects(age=20).count())
-        self.assertEquals(1, Employee.objects(age=20).count())
+        self.assertEqual(1, self.Person.objects(age=20).count())
+        self.assertEqual(1, Employee.objects(age=20).count())
 
         joe_bloggs = self.Person.objects.first()
         self.assertTrue(isinstance(joe_bloggs, Employee))
@@ -175,7 +175,7 @@ class DynamicDocTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, {'hello': 'world'}]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(
+        self.assertEqual(
             doc.to_mongo(),
             {"_cls": "Doc",
              "embedded_field": {
@@ -187,11 +187,11 @@ class DynamicDocTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc.embedded_field.__class__, Embedded)
-        self.assertEquals(doc.embedded_field.string_field, "hello")
-        self.assertEquals(doc.embedded_field.int_field, 1)
-        self.assertEquals(doc.embedded_field.dict_field, {'hello': 'world'})
-        self.assertEquals(doc.embedded_field.list_field,
+        self.assertEqual(doc.embedded_field.__class__, Embedded)
+        self.assertEqual(doc.embedded_field.string_field, "hello")
+        self.assertEqual(doc.embedded_field.int_field, 1)
+        self.assertEqual(doc.embedded_field.dict_field, {'hello': 'world'})
+        self.assertEqual(doc.embedded_field.list_field,
                           ['1', 2, {'hello': 'world'}])
 
     def test_complex_embedded_documents(self):
@@ -219,7 +219,7 @@ class DynamicDocTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, embedded_2]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(
+        self.assertEqual(
             doc.to_mongo(),
             {"_cls": "Doc",
              "embedded_field": {
@@ -236,20 +236,20 @@ class DynamicDocTest(unittest.TestCase):
                                 "list_field": ['1', 2, {'hello': 'world'}]}]}})
         doc.save()
         doc = Doc.objects.first()
-        self.assertEquals(doc.embedded_field.__class__, Embedded)
-        self.assertEquals(doc.embedded_field.string_field, "hello")
-        self.assertEquals(doc.embedded_field.int_field, 1)
-        self.assertEquals(doc.embedded_field.dict_field, {'hello': 'world'})
-        self.assertEquals(doc.embedded_field.list_field[0], '1')
-        self.assertEquals(doc.embedded_field.list_field[1], 2)
+        self.assertEqual(doc.embedded_field.__class__, Embedded)
+        self.assertEqual(doc.embedded_field.string_field, "hello")
+        self.assertEqual(doc.embedded_field.int_field, 1)
+        self.assertEqual(doc.embedded_field.dict_field, {'hello': 'world'})
+        self.assertEqual(doc.embedded_field.list_field[0], '1')
+        self.assertEqual(doc.embedded_field.list_field[1], 2)
 
         embedded_field = doc.embedded_field.list_field[2]
 
-        self.assertEquals(embedded_field.__class__, Embedded)
-        self.assertEquals(embedded_field.string_field, "hello")
-        self.assertEquals(embedded_field.int_field, 1)
-        self.assertEquals(embedded_field.dict_field, {'hello': 'world'})
-        self.assertEquals(embedded_field.list_field,
+        self.assertEqual(embedded_field.__class__, Embedded)
+        self.assertEqual(embedded_field.string_field, "hello")
+        self.assertEqual(embedded_field.int_field, 1)
+        self.assertEqual(embedded_field.dict_field, {'hello': 'world'})
+        self.assertEqual(embedded_field.list_field,
                           ['1', 2, {'hello': 'world'}])
 
     def test_delta_for_dynamic_documents(self):
@@ -259,18 +259,18 @@ class DynamicDocTest(unittest.TestCase):
         p.save()
 
         p.age = 24
-        self.assertEquals(p.age, 24)
-        self.assertEquals(p._get_changed_fields(), ['age'])
-        self.assertEquals(p._delta(), ({'age': 24}, {}))
+        self.assertEqual(p.age, 24)
+        self.assertEqual(p._get_changed_fields(), ['age'])
+        self.assertEqual(p._delta(), ({'age': 24}, {}))
 
         p = self.Person.objects(age=22).get()
         p.age = 24
-        self.assertEquals(p.age, 24)
-        self.assertEquals(p._get_changed_fields(), ['age'])
-        self.assertEquals(p._delta(), ({'age': 24}, {}))
+        self.assertEqual(p.age, 24)
+        self.assertEqual(p._get_changed_fields(), ['age'])
+        self.assertEqual(p._delta(), ({'age': 24}, {}))
 
         p.save()
-        self.assertEquals(1, self.Person.objects(age=24).count())
+        self.assertEqual(1, self.Person.objects(age=24).count())
 
     def test_delta(self):
 
@@ -282,40 +282,40 @@ class DynamicDocTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         doc.string_field = 'hello'
-        self.assertEquals(doc._get_changed_fields(), ['string_field'])
-        self.assertEquals(doc._delta(), ({'string_field': 'hello'}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['string_field'])
+        self.assertEqual(doc._delta(), ({'string_field': 'hello'}, {}))
 
         doc._changed_fields = []
         doc.int_field = 1
-        self.assertEquals(doc._get_changed_fields(), ['int_field'])
-        self.assertEquals(doc._delta(), ({'int_field': 1}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['int_field'])
+        self.assertEqual(doc._delta(), ({'int_field': 1}, {}))
 
         doc._changed_fields = []
         dict_value = {'hello': 'world', 'ping': 'pong'}
         doc.dict_field = dict_value
-        self.assertEquals(doc._get_changed_fields(), ['dict_field'])
-        self.assertEquals(doc._delta(), ({'dict_field': dict_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['dict_field'])
+        self.assertEqual(doc._delta(), ({'dict_field': dict_value}, {}))
 
         doc._changed_fields = []
         list_value = ['1', 2, {'hello': 'world'}]
         doc.list_field = list_value
-        self.assertEquals(doc._get_changed_fields(), ['list_field'])
-        self.assertEquals(doc._delta(), ({'list_field': list_value}, {}))
+        self.assertEqual(doc._get_changed_fields(), ['list_field'])
+        self.assertEqual(doc._delta(), ({'list_field': list_value}, {}))
 
         # Test unsetting
         doc._changed_fields = []
         doc.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(), ['dict_field'])
-        self.assertEquals(doc._delta(), ({}, {'dict_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['dict_field'])
+        self.assertEqual(doc._delta(), ({}, {'dict_field': 1}))
 
         doc._changed_fields = []
         doc.list_field = []
-        self.assertEquals(doc._get_changed_fields(), ['list_field'])
-        self.assertEquals(doc._delta(), ({}, {'list_field': 1}))
+        self.assertEqual(doc._get_changed_fields(), ['list_field'])
+        self.assertEqual(doc._delta(), ({}, {'list_field': 1}))
 
     def test_delta_recursive(self):
         """Testing deltaing works with dynamic documents"""
@@ -330,8 +330,8 @@ class DynamicDocTest(unittest.TestCase):
         doc.save()
 
         doc = Doc.objects.first()
-        self.assertEquals(doc._get_changed_fields(), [])
-        self.assertEquals(doc._delta(), ({}, {}))
+        self.assertEqual(doc._get_changed_fields(), [])
+        self.assertEqual(doc._delta(), ({}, {}))
 
         embedded_1 = Embedded()
         embedded_1.string_field = 'hello'
@@ -340,7 +340,7 @@ class DynamicDocTest(unittest.TestCase):
         embedded_1.list_field = ['1', 2, {'hello': 'world'}]
         doc.embedded_field = embedded_1
 
-        self.assertEquals(doc._get_changed_fields(), ['embedded_field'])
+        self.assertEqual(doc._get_changed_fields(), ['embedded_field'])
 
         embedded_delta = {
             'string_field': 'hello',
@@ -348,30 +348,30 @@ class DynamicDocTest(unittest.TestCase):
             'dict_field': {'hello': 'world'},
             'list_field': ['1', 2, {'hello': 'world'}]
         }
-        self.assertEquals(doc.embedded_field._delta(), (embedded_delta, {}))
+        self.assertEqual(doc.embedded_field._delta(), (embedded_delta, {}))
         embedded_delta.update({
             '_cls': 'Embedded',
         })
-        self.assertEquals(doc._delta(),
+        self.assertEqual(doc._delta(),
                           ({'embedded_field': embedded_delta}, {}))
 
         doc.save()
         doc.reload()
 
         doc.embedded_field.dict_field = {}
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.dict_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
+        self.assertEqual(doc.embedded_field._delta(), ({}, {'dict_field': 1}))
 
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
+        self.assertEqual(doc._delta(), ({}, {'embedded_field.dict_field': 1}))
         doc.save()
         doc.reload()
 
         doc.embedded_field.list_field = []
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({}, {'list_field': 1}))
-        self.assertEquals(doc._delta(), ({}, {'embedded_field.list_field': 1}))
+        self.assertEqual(doc.embedded_field._delta(), ({}, {'list_field': 1}))
+        self.assertEqual(doc._delta(), ({}, {'embedded_field.list_field': 1}))
         doc.save()
         doc.reload()
 
@@ -382,9 +382,9 @@ class DynamicDocTest(unittest.TestCase):
         embedded_2.list_field = ['1', 2, {'hello': 'world'}]
 
         doc.embedded_field.list_field = ['1', 2, embedded_2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(doc.embedded_field._delta(), ({
+        self.assertEqual(doc.embedded_field._delta(), ({
             'list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'string_field': 'hello',
@@ -394,7 +394,7 @@ class DynamicDocTest(unittest.TestCase):
             }]
         }, {}))
 
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field': [
                 '1',
@@ -408,34 +408,34 @@ class DynamicDocTest(unittest.TestCase):
         doc.save()
         doc.reload()
 
-        self.assertEquals(doc.embedded_field.list_field[2]._changed_fields, [])
-        self.assertEquals(doc.embedded_field.list_field[0], '1')
-        self.assertEquals(doc.embedded_field.list_field[1], 2)
+        self.assertEqual(doc.embedded_field.list_field[2]._changed_fields, [])
+        self.assertEqual(doc.embedded_field.list_field[0], '1')
+        self.assertEqual(doc.embedded_field.list_field[1], 2)
         for k in doc.embedded_field.list_field[2]._fields:
-            self.assertEquals(doc.embedded_field.list_field[2][k],
+            self.assertEqual(doc.embedded_field.list_field[2][k],
                               embedded_2[k])
 
         doc.embedded_field.list_field[2].string_field = 'world'
-        self.assertEquals(
+        self.assertEqual(
             doc._get_changed_fields(),
             ['embedded_field.list_field.2.string_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'list_field.2.string_field': 'world'}, {}))
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.string_field': 'world'}, {}))
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'world')
 
         # Test multiple assignments
         doc.embedded_field.list_field[2].string_field = 'hello world'
         doc.embedded_field.list_field[2] = doc.embedded_field.list_field[2]
-        self.assertEquals(doc._get_changed_fields(),
+        self.assertEqual(doc._get_changed_fields(),
                           ['embedded_field.list_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field._delta(),
             ({'list_field': ['1', 2, {
               '_cls': 'Embedded',
@@ -444,7 +444,7 @@ class DynamicDocTest(unittest.TestCase):
               'list_field': ['1', 2, {'hello': 'world'}],
               'dict_field': {'hello': 'world'}}]},
              {}))
-        self.assertEquals(doc._delta(), ({
+        self.assertEqual(doc._delta(), ({
             'embedded_field.list_field': ['1', 2, {
                 '_cls': 'Embedded',
                 'string_field': 'hello world',
@@ -454,12 +454,12 @@ class DynamicDocTest(unittest.TestCase):
             ]}, {}))
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].string_field,
+        self.assertEqual(doc.embedded_field.list_field[2].string_field,
                           'hello world')
 
         # Test list native methods
         doc.embedded_field.list_field[2].list_field.pop(0)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [2,
                                                          {'hello': 'world'}]},
@@ -468,7 +468,7 @@ class DynamicDocTest(unittest.TestCase):
         doc.reload()
 
         doc.embedded_field.list_field[2].list_field.append(1)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [2,
                                                          {'hello': 'world'},
@@ -476,25 +476,25 @@ class DynamicDocTest(unittest.TestCase):
              {}))
         doc.save()
         doc.reload()
-        self.assertEquals(
+        self.assertEqual(
             doc.embedded_field.list_field[2].list_field,
             [2, {'hello': 'world'}, 1])
 
         doc.embedded_field.list_field[2].list_field.sort()
         doc.save()
         doc.reload()
-        self.assertEquals(doc.embedded_field.list_field[2].list_field,
+        self.assertEqual(doc.embedded_field.list_field[2].list_field,
                           [1, 2, {'hello': 'world'}])
 
         del(doc.embedded_field.list_field[2].list_field[2]['hello'])
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'embedded_field.list_field.2.list_field': [1, 2, {}]}, {}))
         doc.save()
         doc.reload()
 
         del(doc.embedded_field.list_field[2].list_field)
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({}, {'embedded_field.list_field.2.list_field': 1}))
 
@@ -506,10 +506,10 @@ class DynamicDocTest(unittest.TestCase):
         doc.reload()
 
         doc.dict_field['embedded'].string_field = 'Hello World'
-        self.assertEquals(
+        self.assertEqual(
             doc._get_changed_fields(),
             ['dict_field.embedded.string_field'])
-        self.assertEquals(
+        self.assertEqual(
             doc._delta(),
             ({'dict_field.embedded.string_field': 'Hello World'}, {}))
 

--- a/tests/dynamic_document.py
+++ b/tests/dynamic_document.py
@@ -1,5 +1,6 @@
 import unittest
 
+import six
 from mongoengine import (
     connect, StringField, IntField,
     DynamicDocument, DynamicEmbeddedDocument)
@@ -480,7 +481,8 @@ class DynamicDocTest(unittest.TestCase):
             doc.embedded_field.list_field[2].list_field,
             [2, {'hello': 'world'}, 1])
 
-        doc.embedded_field.list_field[2].list_field.sort()
+        doc.embedded_field.list_field[2].list_field.sort(
+            key=lambda i: six.text_type(i))
         doc.save()
         doc.reload()
         self.assertEqual(doc.embedded_field.list_field[2].list_field,

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1605,7 +1605,8 @@ class FieldTest(unittest.TestCase):
         TestImage.drop_collection()
 
         t = TestImage()
-        t.image.put(open(TEST_IMAGE_PATH, 'r'))
+        with open(TEST_IMAGE_PATH, 'rb') as f:
+            t.image.put(f)
         t.save()
 
         t = TestImage.objects.first()
@@ -1626,7 +1627,8 @@ class FieldTest(unittest.TestCase):
         TestImage.drop_collection()
 
         t = TestImage()
-        t.image.put(open(TEST_IMAGE_PATH, 'r'))
+        with open(TEST_IMAGE_PATH, 'rb') as f:
+            t.image.put(f)
         t.save()
 
         t = TestImage.objects.first()
@@ -1647,7 +1649,8 @@ class FieldTest(unittest.TestCase):
         TestImage.drop_collection()
 
         t = TestImage()
-        t.image.put(open(TEST_IMAGE_PATH, 'r'))
+        with open(TEST_IMAGE_PATH, 'rb') as f:
+            t.image.put(f)
         t.save()
 
         t = TestImage.objects.first()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -389,7 +389,7 @@ class FieldTest(unittest.TestCase):
         # Pre UTC microseconds above 1000 is wonky - with default datetimefields
         # log.date has an invalid microsecond value so I can't construct
         # a date to compare.
-        for i in xrange(1001, 3113, 33):
+        for i in range(1001, 3113, 33):
             d1 = datetime.datetime(1969, 12, 31, 23, 59, 59, i)
             log.date = d1
             log.save()
@@ -420,7 +420,7 @@ class FieldTest(unittest.TestCase):
         LogEntry.drop_collection()
 
         # create 60 log entries
-        for i in xrange(1950, 2010):
+        for i in range(1950, 2010):
             d = datetime.datetime(i, 01, 01, 00, 00, 01, 999)
             LogEntry(date=d).save()
 
@@ -1707,7 +1707,7 @@ class FieldTest(unittest.TestCase):
         self.db['mongoengine.counters'].drop()
         Person.drop_collection()
 
-        for x in xrange(10):
+        for x in range(10):
             p = Person(name="Person %s" % x)
             p.save()
 
@@ -1715,7 +1715,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(c['next'], 10)
 
         ids = [i.id for i in Person.objects]
-        self.assertEqual(ids, range(1, 11))
+        self.assertEqual(ids, list(range(1, 11)))
 
         c = self.db['mongoengine.counters'].find_one({'_id': 'person.id'})
         self.assertEqual(c['next'], 10)
@@ -1729,7 +1729,7 @@ class FieldTest(unittest.TestCase):
         self.db['mongoengine.counters'].drop()
         Person.drop_collection()
 
-        for x in xrange(10):
+        for x in range(10):
             p = Person(name="Person %s" % x)
             p.save()
 
@@ -1737,10 +1737,10 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(c['next'], 10)
 
         ids = [i.id for i in Person.objects]
-        self.assertEqual(ids, range(1, 11))
+        self.assertEqual(ids, list(range(1, 11)))
 
         counters = [i.counter for i in Person.objects]
-        self.assertEqual(counters, range(1, 11))
+        self.assertEqual(counters, list(range(1, 11)))
 
         c = self.db['mongoengine.counters'].find_one({'_id': 'person.id'})
         self.assertEqual(c['next'], 10)
@@ -1783,7 +1783,7 @@ class FieldTest(unittest.TestCase):
         Animal.drop_collection()
         Person.drop_collection()
 
-        for x in xrange(10):
+        for x in range(10):
             a = Animal(name="Animal %s" % x)
             a.save()
             p = Person(name="Person %s" % x)
@@ -1796,10 +1796,10 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(c['next'], 10)
 
         ids = [i.id for i in Person.objects]
-        self.assertEqual(ids, range(1, 11))
+        self.assertEqual(ids, list(range(1, 11)))
 
         id = [i.id for i in Animal.objects]
-        self.assertEqual(id, range(1, 11))
+        self.assertEqual(id, list(range(1, 11)))
 
         c = self.db['mongoengine.counters'].find_one({'_id': 'person.id'})
         self.assertEqual(c['next'], 10)

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -322,8 +322,8 @@ class FieldTest(unittest.TestCase):
         LogEntry.drop_collection()
 
         # Post UTC - microseconds are rounded (down) nearest millisecond
-        d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 999)
-        d2 = datetime.datetime(1970, 01, 01, 00, 00, 01)
+        d1 = datetime.datetime(1970, 1, 1, 0, 0, 1, 999)
+        d2 = datetime.datetime(1970, 1, 1, 0, 0, 1)
         log = LogEntry()
         log.date = d1
         log.save()
@@ -332,8 +332,8 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(log.date, d2)
 
         # Post UTC - microseconds are rounded (down) nearest millisecond
-        d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 9999)
-        d2 = datetime.datetime(1970, 01, 01, 00, 00, 01, 9000)
+        d1 = datetime.datetime(1970, 1, 1, 0, 0, 1, 9999)
+        d2 = datetime.datetime(1970, 1, 1, 0, 0, 1, 9000)
         log.date = d1
         log.save()
         log.reload()
@@ -363,7 +363,7 @@ class FieldTest(unittest.TestCase):
 
         # Post UTC - microseconds are rounded (down) nearest millisecond and
         # dropped - with default datetimefields
-        d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 999)
+        d1 = datetime.datetime(1970, 1, 1, 0, 0, 1, 999)
         log = LogEntry()
         log.date = d1
         log.save()
@@ -372,7 +372,7 @@ class FieldTest(unittest.TestCase):
 
         # Post UTC - microseconds are rounded (down) nearest millisecond -
         # with default datetimefields
-        d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 9999)
+        d1 = datetime.datetime(1970, 1, 1, 0, 0, 1, 9999)
         log.date = d1
         log.save()
         log.reload()
@@ -409,7 +409,7 @@ class FieldTest(unittest.TestCase):
 
         LogEntry.drop_collection()
 
-        d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 999)
+        d1 = datetime.datetime(1970, 1, 1, 0, 0, 1, 999)
         log = LogEntry()
         log.date = d1
         log.save()
@@ -421,7 +421,7 @@ class FieldTest(unittest.TestCase):
 
         # create 60 log entries
         for i in range(1950, 2010):
-            d = datetime.datetime(i, 01, 01, 00, 00, 01, 999)
+            d = datetime.datetime(i, 1, 1, 0, 0, 1, 999)
             LogEntry(date=d).save()
 
         self.assertEqual(LogEntry.objects.count(), 60)

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -5,7 +5,15 @@ import uuid
 
 from decimal import Decimal
 
-from mongoengine import *
+from mongoengine import (
+    connect, ValidationError,
+    StringField, IntField, BooleanField, URLField, UUIDField,
+    BinaryField, DateTimeField, ComplexDateTimeField,
+    FileField, ImageField, FloatField, DecimalField,
+    ListField, MapField, DictField, SortedListField,
+    SequenceField, ReferenceField, GenericReferenceField,
+    Document, EmbeddedDocument,
+    EmbeddedDocumentField, GenericEmbeddedDocumentField)
 from mongoengine.connection import get_db, register_db
 from mongoengine.base import _document_registry
 
@@ -25,7 +33,8 @@ class FieldTest(unittest.TestCase):
         class Person(Document):
             name = StringField()
             age = IntField(default=30, help_text="Your real age")
-            userid = StringField(default=lambda: 'test', verbose_name="User Identity")
+            userid = StringField(default=lambda: 'test',
+                                 verbose_name="User Identity")
 
         person = Person(name='Test Person')
         self.assertEqual(person._data['age'], 30)
@@ -551,7 +560,8 @@ class FieldTest(unittest.TestCase):
             name = StringField()
 
         class CategoryList(Document):
-            categories = SortedListField(EmbeddedDocumentField(Category), ordering='count', reverse=True)
+            categories = SortedListField(EmbeddedDocumentField(Category),
+                                         ordering='count', reverse=True)
             name = StringField()
 
         catlist = CategoryList(name="Top categories")
@@ -877,11 +887,11 @@ class FieldTest(unittest.TestCase):
         Simple.objects().update(
             set__mapping__nested_dict__list__1=StringSetting(value='Boo'))
         self.assertEquals(
-            Simple.objects.filter(mapping__nested_dict__list__1__value='foo') \
+            Simple.objects.filter(mapping__nested_dict__list__1__value='foo')
                           .count(),
             0)
         self.assertEquals(
-            Simple.objects.filter(mapping__nested_dict__list__1__value='Boo') \
+            Simple.objects.filter(mapping__nested_dict__list__1__value='Boo')
                           .count(),
             1)
 
@@ -1305,7 +1315,7 @@ class FieldTest(unittest.TestCase):
         Person(name="Wilson Jr").save()
 
         self.assertEquals(repr(Person.objects(city=None)),
-                            "[<Person: Person object>]")
+                          "[<Person: Person object>]")
 
     def test_binary_fields(self):
         """Ensure that binary fields can be stored and retrieved.
@@ -1367,8 +1377,10 @@ class FieldTest(unittest.TestCase):
         """Ensure that value is in a container of allowed values.
         """
         class Shirt(Document):
-            size = StringField(max_length=3, choices=(('S', 'Small'), ('M', 'Medium'), ('L', 'Large'),
-                                                      ('XL', 'Extra Large'), ('XXL', 'Extra Extra Large')))
+            size = StringField(
+                max_length=3,
+                choices=(('S', 'Small'), ('M', 'Medium'), ('L', 'Large'),
+                         ('XL', 'Extra Large'), ('XXL', 'Extra Extra Large')))
 
         Shirt.drop_collection()
 
@@ -1387,9 +1399,14 @@ class FieldTest(unittest.TestCase):
         """Test dynamic helper for returning the display value of a choices field.
         """
         class Shirt(Document):
-            size = StringField(max_length=3, choices=(('S', 'Small'), ('M', 'Medium'), ('L', 'Large'),
-                                                      ('XL', 'Extra Large'), ('XXL', 'Extra Extra Large')))
-            style = StringField(max_length=3, choices=(('S', 'Small'), ('B', 'Baggy'), ('W', 'wide')), default='S')
+            size = StringField(
+                max_length=3,
+                choices=(('S', 'Small'), ('M', 'Medium'), ('L', 'Large'),
+                         ('XL', 'Extra Large'), ('XXL', 'Extra Extra Large')))
+            style = StringField(
+                max_length=3,
+                choices=(('S', 'Small'), ('B', 'Baggy'), ('W', 'wide')),
+                default='S')
 
         Shirt.drop_collection()
 
@@ -1416,7 +1433,8 @@ class FieldTest(unittest.TestCase):
         """Ensure that value is in a container of allowed values.
         """
         class Shirt(Document):
-            size = StringField(max_length=3, choices=('S', 'M', 'L', 'XL', 'XXL'))
+            size = StringField(max_length=3,
+                               choices=('S', 'M', 'L', 'XL', 'XXL'))
 
         Shirt.drop_collection()
 
@@ -1435,8 +1453,11 @@ class FieldTest(unittest.TestCase):
         """Test dynamic helper for returning the display value of a choices field.
         """
         class Shirt(Document):
-            size = StringField(max_length=3, choices=('S', 'M', 'L', 'XL', 'XXL'))
-            style = StringField(max_length=3, choices=('Small', 'Baggy', 'wide'), default='Small')
+            size = StringField(max_length=3,
+                               choices=('S', 'M', 'L', 'XL', 'XXL'))
+            style = StringField(max_length=3,
+                                choices=('Small', 'Baggy', 'wide'),
+                                default='Small')
 
         Shirt.drop_collection()
 
@@ -1639,6 +1660,7 @@ class FieldTest(unittest.TestCase):
     def test_file_multidb(self):
         connect()
         register_db('testfiles', 'testfiles')
+
         class TestFile(Document):
             name = StringField()
             file = FileField(db_alias="testfiles",

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -5,6 +5,7 @@ import uuid
 
 from decimal import Decimal
 
+import six
 from mongoengine import (
     connect, ValidationError,
     StringField, IntField, BooleanField, URLField, UUIDField,
@@ -340,15 +341,16 @@ class FieldTest(unittest.TestCase):
         self.assertNotEqual(log.date, d1)
         self.assertEqual(log.date, d2)
 
-        # Pre UTC dates microseconds below 1000 are dropped
-        # This does not seem to be true in PY3
-        d1 = datetime.datetime(1969, 12, 31, 23, 59, 59, 999)
-        d2 = datetime.datetime(1969, 12, 31, 23, 59, 59)
-        log.date = d1
-        log.save()
-        log.reload()
-        self.assertNotEqual(log.date, d1)
-        self.assertEqual(log.date, d2)
+        if not six.PY3:
+            # Pre UTC dates microseconds below 1000 are dropped
+            # This does not seem to be true in PY3
+            d1 = datetime.datetime(1969, 12, 31, 23, 59, 59, 999)
+            d2 = datetime.datetime(1969, 12, 31, 23, 59, 59)
+            log.date = d1
+            log.save()
+            log.reload()
+            self.assertNotEqual(log.date, d1)
+            self.assertEqual(log.date, d2)
 
         LogEntry.drop_collection()
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 from mongoengine import *
 from mongoengine.connection import get_db, register_db
-from mongoengine.base import _document_registry, NotRegistered
+from mongoengine.base import _document_registry
 
 TEST_IMAGE_PATH = os.path.join(os.path.dirname(__file__), 'mongoengine.png')
 
@@ -104,7 +104,7 @@ class FieldTest(unittest.TestCase):
         doc.save()
 
         collection = self.db[HandleNoneFields._get_collection_name()]
-        obj = collection.update({"_id": doc.id}, {"$unset": {
+        collection.update({"_id": doc.id}, {"$unset": {
             "str_fld": 1,
             "int_fld": 1,
             "flt_fld": 1,
@@ -312,7 +312,7 @@ class FieldTest(unittest.TestCase):
 
         LogEntry.drop_collection()
 
-        # Post UTC - microseconds are rounded (down) nearest millisecond and dropped
+        # Post UTC - microseconds are rounded (down) nearest millisecond
         d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 999)
         d2 = datetime.datetime(1970, 01, 01, 00, 00, 01)
         log = LogEntry()
@@ -352,7 +352,8 @@ class FieldTest(unittest.TestCase):
 
         LogEntry.drop_collection()
 
-        # Post UTC - microseconds are rounded (down) nearest millisecond and dropped - with default datetimefields
+        # Post UTC - microseconds are rounded (down) nearest millisecond and
+        # dropped - with default datetimefields
         d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 999)
         log = LogEntry()
         log.date = d1
@@ -360,14 +361,16 @@ class FieldTest(unittest.TestCase):
         log.reload()
         self.assertEquals(log.date, d1)
 
-        # Post UTC - microseconds are rounded (down) nearest millisecond - with default datetimefields
+        # Post UTC - microseconds are rounded (down) nearest millisecond -
+        # with default datetimefields
         d1 = datetime.datetime(1970, 01, 01, 00, 00, 01, 9999)
         log.date = d1
         log.save()
         log.reload()
         self.assertEquals(log.date, d1)
 
-        # Pre UTC dates microseconds below 1000 are dropped - with default datetimefields
+        # Pre UTC dates microseconds below 1000 are dropped -
+        # with default datetimefields
         d1 = datetime.datetime(1969, 12, 31, 23, 59, 59, 999)
         log.date = d1
         log.save()
@@ -592,12 +595,20 @@ class FieldTest(unittest.TestCase):
         post.save()
 
         self.assertEquals(BlogPost.objects.count(), 3)
-        self.assertEquals(BlogPost.objects.filter(info__exact='test').count(), 1)
-        self.assertEquals(BlogPost.objects.filter(info__0__test='test').count(), 1)
+        self.assertEquals(
+            BlogPost.objects.filter(info__exact='test').count(),
+            1)
+        self.assertEquals(
+            BlogPost.objects.filter(info__0__test='test').count(),
+            1)
 
         # Confirm handles non strings or non existing keys
-        self.assertEquals(BlogPost.objects.filter(info__0__test__exact='5').count(), 0)
-        self.assertEquals(BlogPost.objects.filter(info__100__test__exact='test').count(), 0)
+        self.assertEquals(
+            BlogPost.objects.filter(info__0__test__exact='5').count(),
+            0)
+        self.assertEquals(
+            BlogPost.objects.filter(info__100__test__exact='test').count(),
+            0)
         BlogPost.drop_collection()
 
     def test_list_field_passed_in_value(self):
@@ -614,9 +625,9 @@ class FieldTest(unittest.TestCase):
         foo.bars.append(bar)
         self.assertEquals(repr(foo.bars), '[<Bar: Bar object>]')
 
-
     def test_list_field_strict(self):
-        """Ensure that list field handles validation if provided a strict field type."""
+        """Ensure that list field handles validation if provided a
+        strict field type."""
 
         class Simple(Document):
             mapping = ListField(field=IntField())
@@ -687,28 +698,47 @@ class FieldTest(unittest.TestCase):
         e = Simple()
         e.mapping.append(StringSetting(value='foo'))
         e.mapping.append(IntegerSetting(value=42))
-        e.mapping.append({'number': 1, 'string': 'Hi!', 'float': 1.001,
-                          'complex': IntegerSetting(value=42), 'list':
-                          [IntegerSetting(value=42), StringSetting(value='foo')]})
+        e.mapping.append(
+            {'number': 1,
+             'string': 'Hi!',
+             'float': 1.001,
+             'complex': IntegerSetting(value=42),
+             'list': [IntegerSetting(value=42), StringSetting(value='foo')]})
         e.save()
 
-        e2 = Simple.objects.get(id=e.id)
+        Simple.objects.get(id=e.id)
 
         # Test querying
-        self.assertEquals(Simple.objects.filter(mapping__1__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__2__number=1).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__2__complex__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__2__list__0__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__2__list__1__value='foo').count(), 1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__1__value=42).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__number=1).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__complex__value=42).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__list__0__value=42).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__list__1__value='foo').count(),
+            1)
 
         # Confirm can update
         Simple.objects().update(set__mapping__1=IntegerSetting(value=10))
-        self.assertEquals(Simple.objects.filter(mapping__1__value=10).count(), 1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__1__value=10).count(),
+            1)
 
         Simple.objects().update(
             set__mapping__2__list__1=StringSetting(value='Boo'))
-        self.assertEquals(Simple.objects.filter(mapping__2__list__1__value='foo').count(), 0)
-        self.assertEquals(Simple.objects.filter(mapping__2__list__1__value='Boo').count(), 1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__list__1__value='foo').count(),
+            0)
+        self.assertEquals(
+            Simple.objects.filter(mapping__2__list__1__value='Boo').count(),
+            1)
 
         Simple.drop_collection()
 
@@ -748,12 +778,20 @@ class FieldTest(unittest.TestCase):
         post.save()
 
         self.assertEquals(BlogPost.objects.count(), 3)
-        self.assertEquals(BlogPost.objects.filter(info__title__exact='test').count(), 1)
-        self.assertEquals(BlogPost.objects.filter(info__details__test__exact='test').count(), 1)
+        self.assertEquals(
+            BlogPost.objects.filter(info__title__exact='test').count(),
+            1)
+        self.assertEquals(
+            BlogPost.objects.filter(info__details__test__exact='test').count(),
+            1)
 
         # Confirm handles non strings or non existing keys
-        self.assertEquals(BlogPost.objects.filter(info__details__test__exact=5).count(), 0)
-        self.assertEquals(BlogPost.objects.filter(info__made_up__test__exact='test').count(), 0)
+        self.assertEquals(
+            BlogPost.objects.filter(info__details__test__exact=5).count(),
+            0)
+        self.assertEquals(
+            BlogPost.objects.filter(info__made_up__test__exact='test').count(),
+            0)
 
         post = BlogPost.objects.create(info={'title': 'original'})
         post.info.update({'title': 'updated'})
@@ -764,7 +802,8 @@ class FieldTest(unittest.TestCase):
         BlogPost.drop_collection()
 
     def test_dictfield_strict(self):
-        """Ensure that dict field handles validation if provided a strict field type."""
+        """Ensure that dict field handles validation if provided a strict
+        field type."""
 
         class Simple(Document):
             mapping = DictField(field=IntField())
@@ -802,27 +841,49 @@ class FieldTest(unittest.TestCase):
         e = Simple()
         e.mapping['somestring'] = StringSetting(value='foo')
         e.mapping['someint'] = IntegerSetting(value=42)
-        e.mapping['nested_dict'] = {'number': 1, 'string': 'Hi!', 'float': 1.001,
-                                 'complex': IntegerSetting(value=42), 'list':
-                                [IntegerSetting(value=42), StringSetting(value='foo')]}
+        e.mapping['nested_dict'] = {
+            'number': 1,
+            'string': 'Hi!',
+            'float': 1.001,
+            'complex': IntegerSetting(value=42),
+            'list': [IntegerSetting(value=42), StringSetting(value='foo')]}
         e.save()
 
-        e2 = Simple.objects.get(id=e.id)
+        Simple.objects.get(id=e.id)
 
         # Test querying
-        self.assertEquals(Simple.objects.filter(mapping__someint__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__number=1).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__complex__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__list__0__value=42).count(), 1)
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__list__1__value='foo').count(), 1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__someint__value=42).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__number=1).count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__complex__value=42)
+                          .count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__list__0__value=42)
+                          .count(),
+            1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__list__1__value='foo')
+                          .count(),
+            1)
 
         # Confirm can update
         Simple.objects().update(
             set__mapping={"someint": IntegerSetting(value=10)})
         Simple.objects().update(
             set__mapping__nested_dict__list__1=StringSetting(value='Boo'))
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__list__1__value='foo').count(), 0)
-        self.assertEquals(Simple.objects.filter(mapping__nested_dict__list__1__value='Boo').count(), 1)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__list__1__value='foo') \
+                          .count(),
+            0)
+        self.assertEquals(
+            Simple.objects.filter(mapping__nested_dict__list__1__value='Boo') \
+                          .count(),
+            1)
 
         Simple.drop_collection()
 
@@ -994,8 +1055,7 @@ class FieldTest(unittest.TestCase):
         group = Group(members=[user1, user2])
         group.save()
 
-        group_obj = Group.objects.first()
-
+        Group.objects.first()
         User.drop_collection()
         Group.drop_collection()
 
@@ -1427,7 +1487,7 @@ class FieldTest(unittest.TestCase):
         self.assertTrue(putfile == result)
         self.assertEquals(result.file.read(), text)
         self.assertEquals(result.file.content_type, content_type)
-        result.file.delete() # Remove file from GridFS
+        result.file.delete()  # Remove file from GridFS
 
         streamfile = StreamFile()
         streamfile.file.new_file(content_type=content_type)
@@ -1449,7 +1509,7 @@ class FieldTest(unittest.TestCase):
         result.file.delete()
 
         # Ensure deleted file returns None
-        self.assertTrue(result.file.read() == None)
+        self.assertTrue(result.file.read() is None)
 
         setfile = SetFile()
         setfile.file = text
@@ -1475,6 +1535,7 @@ class FieldTest(unittest.TestCase):
         # Make sure FileField is optional and not required
         class DemoFile(Document):
             file = FileField()
+
         DemoFile.objects.create()
 
     def test_file_uniqueness(self):
@@ -1492,7 +1553,7 @@ class FieldTest(unittest.TestCase):
 
         # Second instance
         testfiledupe = TestFile()
-        data = testfiledupe.file.read() # Should be None
+        data = testfiledupe.file.read()  # Should be None
 
         self.assertTrue(testfile.name != testfiledupe.name)
         self.assertTrue(testfile.file.read() != data)
@@ -1574,7 +1635,6 @@ class FieldTest(unittest.TestCase):
         self.assertEquals(t.image.thumbnail.height, 18)
 
         t.image.delete()
-
 
     def test_file_multidb(self):
         connect()

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1324,7 +1324,7 @@ class FieldTest(unittest.TestCase):
             content_type = StringField()
             blob = BinaryField()
 
-        BLOB = '\xe6\x00\xc4\xff\x07'
+        BLOB = b'\xe6\x00\xc4\xff\x07'
         MIME_TYPE = 'application/octet-stream'
 
         Attachment.drop_collection()
@@ -1361,12 +1361,13 @@ class FieldTest(unittest.TestCase):
 
         attachment_required = AttachmentRequired()
         self.assertRaises(ValidationError, attachment_required.validate)
-        attachment_required.blob = '\xe6\x00\xc4\xff\x07'
+        attachment_required.blob = b'\xe6\x00\xc4\xff\x07'
         attachment_required.validate()
 
-        attachment_size_limit = AttachmentSizeLimit(blob='\xe6\x00\xc4\xff\x07')
+        attachment_size_limit = AttachmentSizeLimit(
+            blob=b'\xe6\x00\xc4\xff\x07')
         self.assertRaises(ValidationError, attachment_size_limit.validate)
-        attachment_size_limit.blob = '\xe6\x00\xc4\xff'
+        attachment_size_limit.blob = b'\xe6\x00\xc4\xff'
         attachment_size_limit.validate()
 
         Attachment.drop_collection()
@@ -1492,8 +1493,8 @@ class FieldTest(unittest.TestCase):
         class SetFile(Document):
             file = FileField()
 
-        text = 'Hello, World!'
-        more_text = 'Foo Bar'
+        text = b'Hello, World!'
+        more_text = b'Foo Bar'
         content_type = 'text/plain'
 
         PutFile.drop_collection()
@@ -1569,7 +1570,7 @@ class FieldTest(unittest.TestCase):
         # First instance
         testfile = TestFile()
         testfile.name = "Hello, World!"
-        testfile.file.put('Hello, World!')
+        testfile.file.put(b'Hello, World!')
         testfile.save()
 
         # Second instance
@@ -1589,7 +1590,7 @@ class FieldTest(unittest.TestCase):
 
         testfile = TestFile()
         self.assertFalse(bool(testfile.file))
-        testfile.file = 'Hello, World!'
+        testfile.file = b'Hello, World!'
         testfile.file.content_type = 'text/plain'
         testfile.save()
         self.assertTrue(bool(testfile.file))
@@ -1675,7 +1676,7 @@ class FieldTest(unittest.TestCase):
         # First instance
         testfile = TestFile()
         testfile.name = "Hello, World!"
-        testfile.file.put('Hello, World!',
+        testfile.file.put(b'Hello, World!',
                           name="hello.txt")
         testfile.save()
 
@@ -1683,8 +1684,8 @@ class FieldTest(unittest.TestCase):
         self.assertEquals(data.get('name'), 'hello.txt')
 
         testfile = TestFile.objects.first()
-        self.assertEquals(testfile.file.read(),
-                          'Hello, World!')
+        self.assertEqual(testfile.file.read(),
+                          b'Hello, World!')
 
     def test_ensure_unique_default_instances(self):
         """Ensure that every field has it's own unique default instance."""

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -127,7 +127,7 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(ret.int_fld, None)
         self.assertEqual(ret.flt_fld, None)
         # Return current time if retrived value is None.
-        self.assert_(isinstance(ret.comp_dt_fld, datetime.datetime))
+        self.assertTrue(isinstance(ret.comp_dt_fld, datetime.datetime))
 
         self.assertRaises(ValidationError, ret.validate)
 
@@ -368,7 +368,7 @@ class FieldTest(unittest.TestCase):
         log.date = d1
         log.save()
         log.reload()
-        self.assertEquals(log.date, d1)
+        self.assertEqual(log.date, d1)
 
         # Post UTC - microseconds are rounded (down) nearest millisecond -
         # with default datetimefields
@@ -376,7 +376,7 @@ class FieldTest(unittest.TestCase):
         log.date = d1
         log.save()
         log.reload()
-        self.assertEquals(log.date, d1)
+        self.assertEqual(log.date, d1)
 
         # Pre UTC dates microseconds below 1000 are dropped -
         # with default datetimefields
@@ -384,7 +384,7 @@ class FieldTest(unittest.TestCase):
         log.date = d1
         log.save()
         log.reload()
-        self.assertEquals(log.date, d1)
+        self.assertEqual(log.date, d1)
 
         # Pre UTC microseconds above 1000 is wonky - with default datetimefields
         # log.date has an invalid microsecond value so I can't construct
@@ -394,7 +394,7 @@ class FieldTest(unittest.TestCase):
             log.date = d1
             log.save()
             log.reload()
-            self.assertEquals(log.date, d1)
+            self.assertEqual(log.date, d1)
             log1 = LogEntry.objects.get(date=d1)
             self.assertEqual(log, log1)
 
@@ -415,7 +415,7 @@ class FieldTest(unittest.TestCase):
         log.save()
 
         log1 = LogEntry.objects.get(date=d1)
-        self.assertEquals(log, log1)
+        self.assertEqual(log, log1)
 
         LogEntry.drop_collection()
 
@@ -604,19 +604,19 @@ class FieldTest(unittest.TestCase):
         post.info = [{'test': 3}]
         post.save()
 
-        self.assertEquals(BlogPost.objects.count(), 3)
-        self.assertEquals(
+        self.assertEqual(BlogPost.objects.count(), 3)
+        self.assertEqual(
             BlogPost.objects.filter(info__exact='test').count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__0__test='test').count(),
             1)
 
         # Confirm handles non strings or non existing keys
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__0__test__exact='5').count(),
             0)
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__100__test__exact='test').count(),
             0)
         BlogPost.drop_collection()
@@ -633,7 +633,7 @@ class FieldTest(unittest.TestCase):
 
         foo = Foo(bars=[])
         foo.bars.append(bar)
-        self.assertEquals(repr(foo.bars), '[<Bar: Bar object>]')
+        self.assertEqual(repr(foo.bars), '[<Bar: Bar object>]')
 
     def test_list_field_strict(self):
         """Ensure that list field handles validation if provided a
@@ -719,34 +719,34 @@ class FieldTest(unittest.TestCase):
         Simple.objects.get(id=e.id)
 
         # Test querying
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__1__value=42).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__number=1).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__complex__value=42).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__list__0__value=42).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__list__1__value='foo').count(),
             1)
 
         # Confirm can update
         Simple.objects().update(set__mapping__1=IntegerSetting(value=10))
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__1__value=10).count(),
             1)
 
         Simple.objects().update(
             set__mapping__2__list__1=StringSetting(value='Boo'))
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__list__1__value='foo').count(),
             0)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__2__list__1__value='Boo').count(),
             1)
 
@@ -787,19 +787,19 @@ class FieldTest(unittest.TestCase):
         post.info = {'details': {'test': 3}}
         post.save()
 
-        self.assertEquals(BlogPost.objects.count(), 3)
-        self.assertEquals(
+        self.assertEqual(BlogPost.objects.count(), 3)
+        self.assertEqual(
             BlogPost.objects.filter(info__title__exact='test').count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__details__test__exact='test').count(),
             1)
 
         # Confirm handles non strings or non existing keys
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__details__test__exact=5).count(),
             0)
-        self.assertEquals(
+        self.assertEqual(
             BlogPost.objects.filter(info__made_up__test__exact='test').count(),
             0)
 
@@ -807,7 +807,7 @@ class FieldTest(unittest.TestCase):
         post.info.update({'title': 'updated'})
         post.save()
         post.reload()
-        self.assertEquals('updated', post.info['title'])
+        self.assertEqual('updated', post.info['title'])
 
         BlogPost.drop_collection()
 
@@ -862,21 +862,21 @@ class FieldTest(unittest.TestCase):
         Simple.objects.get(id=e.id)
 
         # Test querying
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__someint__value=42).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__number=1).count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__complex__value=42)
                           .count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__list__0__value=42)
                           .count(),
             1)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__list__1__value='foo')
                           .count(),
             1)
@@ -886,11 +886,11 @@ class FieldTest(unittest.TestCase):
             set__mapping={"someint": IntegerSetting(value=10)})
         Simple.objects().update(
             set__mapping__nested_dict__list__1=StringSetting(value='Boo'))
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__list__1__value='foo')
                           .count(),
             0)
-        self.assertEquals(
+        self.assertEqual(
             Simple.objects.filter(mapping__nested_dict__list__1__value='Boo')
                           .count(),
             1)
@@ -1314,7 +1314,7 @@ class FieldTest(unittest.TestCase):
         Person.drop_collection()
         Person(name="Wilson Jr").save()
 
-        self.assertEquals(repr(Person.objects(city=None)),
+        self.assertEqual(repr(Person.objects(city=None)),
                           "[<Person: Person object>]")
 
     def test_binary_fields(self):
@@ -1507,8 +1507,8 @@ class FieldTest(unittest.TestCase):
         putfile.validate()
         result = PutFile.objects.first()
         self.assertTrue(putfile == result)
-        self.assertEquals(result.file.read(), text)
-        self.assertEquals(result.file.content_type, content_type)
+        self.assertEqual(result.file.read(), text)
+        self.assertEqual(result.file.content_type, content_type)
         result.file.delete()  # Remove file from GridFS
 
         streamfile = StreamFile()
@@ -1520,14 +1520,14 @@ class FieldTest(unittest.TestCase):
         streamfile.validate()
         result = StreamFile.objects.first()
         self.assertTrue(streamfile == result)
-        self.assertEquals(result.file.read(), text + more_text)
-        self.assertEquals(result.file.content_type, content_type)
+        self.assertEqual(result.file.read(), text + more_text)
+        self.assertEqual(result.file.content_type, content_type)
         result.file.seek(0)
-        self.assertEquals(result.file.tell(), 0)
-        self.assertEquals(result.file.read(len(text)), text)
-        self.assertEquals(result.file.tell(), len(text))
-        self.assertEquals(result.file.read(len(more_text)), more_text)
-        self.assertEquals(result.file.tell(), len(text + more_text))
+        self.assertEqual(result.file.tell(), 0)
+        self.assertEqual(result.file.read(len(text)), text)
+        self.assertEqual(result.file.tell(), len(text))
+        self.assertEqual(result.file.read(len(more_text)), more_text)
+        self.assertEqual(result.file.tell(), len(text + more_text))
         result.file.delete()
 
         # Ensure deleted file returns None
@@ -1539,7 +1539,7 @@ class FieldTest(unittest.TestCase):
         setfile.validate()
         result = SetFile.objects.first()
         self.assertTrue(setfile == result)
-        self.assertEquals(result.file.read(), text)
+        self.assertEqual(result.file.read(), text)
 
         # Try replacing file with new one
         result.file.replace(more_text)
@@ -1547,7 +1547,7 @@ class FieldTest(unittest.TestCase):
         result.validate()
         result = SetFile.objects.first()
         self.assertTrue(setfile == result)
-        self.assertEquals(result.file.read(), more_text)
+        self.assertEqual(result.file.read(), more_text)
         result.file.delete()
 
         PutFile.drop_collection()
@@ -1610,11 +1610,11 @@ class FieldTest(unittest.TestCase):
 
         t = TestImage.objects.first()
 
-        self.assertEquals(t.image.format, 'PNG')
+        self.assertEqual(t.image.format, 'PNG')
 
         w, h = t.image.size
-        self.assertEquals(w, 371)
-        self.assertEquals(h, 76)
+        self.assertEqual(w, 371)
+        self.assertEqual(h, 76)
 
         t.image.delete()
 
@@ -1631,11 +1631,11 @@ class FieldTest(unittest.TestCase):
 
         t = TestImage.objects.first()
 
-        self.assertEquals(t.image.format, 'PNG')
+        self.assertEqual(t.image.format, 'PNG')
         w, h = t.image.size
 
-        self.assertEquals(w, 185)
-        self.assertEquals(h, 37)
+        self.assertEqual(w, 185)
+        self.assertEqual(h, 37)
 
         t.image.delete()
 
@@ -1652,9 +1652,9 @@ class FieldTest(unittest.TestCase):
 
         t = TestImage.objects.first()
 
-        self.assertEquals(t.image.thumbnail.format, 'PNG')
-        self.assertEquals(t.image.thumbnail.width, 92)
-        self.assertEquals(t.image.thumbnail.height, 18)
+        self.assertEqual(t.image.thumbnail.format, 'PNG')
+        self.assertEqual(t.image.thumbnail.width, 92)
+        self.assertEqual(t.image.thumbnail.height, 18)
 
         t.image.delete()
 
@@ -1681,7 +1681,7 @@ class FieldTest(unittest.TestCase):
         testfile.save()
 
         data = get_db("testfiles").macumba.files.find_one()
-        self.assertEquals(data.get('name'), 'hello.txt')
+        self.assertEqual(data.get('name'), 'hello.txt')
 
         testfile = TestFile.objects.first()
         self.assertEqual(testfile.file.read(),
@@ -1852,10 +1852,9 @@ class FieldTest(unittest.TestCase):
         post.comments.append(Comment(content='hello', author=bob))
         post.comments.append(Comment(author=bob))
 
-        try:
+        with self.assertRaises(ValidationError) as context:
             post.validate()
-        except ValidationError, error:
-            pass
+        error = context.exception
 
         # ValidationError.errors property
         self.assertTrue(hasattr(error, 'errors'))
@@ -1871,8 +1870,8 @@ class FieldTest(unittest.TestCase):
         self.assertTrue('comments' in error_dict)
         self.assertTrue(1 in error_dict['comments'])
         self.assertTrue('content' in error_dict['comments'][1])
-        self.assertEquals(error_dict['comments'][1]['content'],
-                          u'Field is required ("content")')
+        self.assertEqual(error_dict['comments'][1]['content'],
+                         u'Field is required ("content")')
 
         post.comments[1].content = 'here we go'
         post.validate()
@@ -1884,12 +1883,12 @@ class ValidatorErrorTest(unittest.TestCase):
         """Ensure a ValidationError handles error to_dict correctly.
         """
         error = ValidationError('root')
-        self.assertEquals(error.to_dict(), {})
+        self.assertEqual(error.to_dict(), {})
 
         # 1st level error schema
         error.errors = {'1st': ValidationError('bad 1st'), }
         self.assertTrue('1st' in error.to_dict())
-        self.assertEquals(error.to_dict()['1st'], 'bad 1st')
+        self.assertEqual(error.to_dict()['1st'], 'bad 1st')
 
         # 2nd level error schema
         error.errors = {'1st': ValidationError('bad 1st', errors={
@@ -1898,7 +1897,7 @@ class ValidatorErrorTest(unittest.TestCase):
         self.assertTrue('1st' in error.to_dict())
         self.assertTrue(isinstance(error.to_dict()['1st'], dict))
         self.assertTrue('2nd' in error.to_dict()['1st'])
-        self.assertEquals(error.to_dict()['1st']['2nd'], 'bad 2nd')
+        self.assertEqual(error.to_dict()['1st']['2nd'], 'bad 2nd')
 
         # moar levels
         error.errors = {'1st': ValidationError('bad 1st', errors={
@@ -1912,7 +1911,7 @@ class ValidatorErrorTest(unittest.TestCase):
         self.assertTrue('2nd' in error.to_dict()['1st'])
         self.assertTrue('3rd' in error.to_dict()['1st']['2nd'])
         self.assertTrue('4th' in error.to_dict()['1st']['2nd']['3rd'])
-        self.assertEquals(error.to_dict()['1st']['2nd']['3rd']['4th'],
+        self.assertEqual(error.to_dict()['1st']['2nd']['3rd']['4th'],
                           'Inception')
 
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -693,8 +693,6 @@ class FieldTest(unittest.TestCase):
         e.save()
 
         e2 = Simple.objects.get(id=e.id)
-        self.assertTrue(isinstance(e2.mapping[0], StringSetting))
-        self.assertTrue(isinstance(e2.mapping[1], IntegerSetting))
 
         # Test querying
         self.assertEquals(Simple.objects.filter(mapping__1__value=42).count(), 1)
@@ -810,8 +808,6 @@ class FieldTest(unittest.TestCase):
         e.save()
 
         e2 = Simple.objects.get(id=e.id)
-        self.assertTrue(isinstance(e2.mapping['somestring'], StringSetting))
-        self.assertTrue(isinstance(e2.mapping['someint'], IntegerSetting))
 
         # Test querying
         self.assertEquals(Simple.objects.filter(mapping__someint__value=42).count(), 1)
@@ -1000,36 +996,8 @@ class FieldTest(unittest.TestCase):
 
         group_obj = Group.objects.first()
 
-        self.assertEqual(group_obj.members[0].name, user1.name)
-        self.assertEqual(group_obj.members[1].name, user2.name)
-
         User.drop_collection()
         Group.drop_collection()
-
-    def test_recursive_reference(self):
-        """Ensure that ReferenceFields can reference their own documents.
-        """
-        class Employee(Document):
-            name = StringField()
-            boss = ReferenceField('self')
-            friends = ListField(ReferenceField('self'))
-
-        bill = Employee(name='Bill Lumbergh')
-        bill.save()
-
-        michael = Employee(name='Michael Bolton')
-        michael.save()
-
-        samir = Employee(name='Samir Nagheenanajar')
-        samir.save()
-
-        friends = [michael, samir]
-        peter = Employee(name='Peter Gibbons', boss=bill, friends=friends)
-        peter.save()
-
-        peter = Employee.objects.with_id(peter.id)
-        self.assertEqual(peter.boss, bill)
-        self.assertEqual(peter.friends, friends)
 
     def test_recursive_embedding(self):
         """Ensure that EmbeddedDocumentFields can contain their own documents.
@@ -1232,8 +1200,8 @@ class FieldTest(unittest.TestCase):
 
         user = User.objects(bookmarks__all=[post_1, link_1]).first()
 
-        self.assertEqual(user.bookmarks[0], post_1)
-        self.assertEqual(user.bookmarks[1], link_1)
+        self.assertEqual(user.bookmarks[0]['_ref'].id, post_1.id)
+        self.assertEqual(user.bookmarks[1]['_ref'].id, link_1.id)
 
         Link.drop_collection()
         Post.drop_collection()
@@ -1263,11 +1231,6 @@ class FieldTest(unittest.TestCase):
         del(_document_registry["Link"])
 
         user = User.objects.first()
-        try:
-            user.bookmarks
-            raise AssertionError("Link was removed from the registry")
-        except NotRegistered:
-            pass
 
         Link.drop_collection()
         User.drop_collection()
@@ -1624,8 +1587,8 @@ class FieldTest(unittest.TestCase):
         TestFile.drop_collection()
 
         # delete old filesystem
-        get_db("testfiles").macumba.files.really_drop()
-        get_db("testfiles").macumba.chunks.really_drop()
+        get_db("testfiles").macumba.files.drop()
+        get_db("testfiles").macumba.chunks.drop()
 
         # First instance
         testfile = TestFile()
@@ -1659,7 +1622,7 @@ class FieldTest(unittest.TestCase):
             id = SequenceField(primary_key=True)
             name = StringField()
 
-        self.db['mongoengine.counters'].really_drop()
+        self.db['mongoengine.counters'].drop()
         Person.drop_collection()
 
         for x in xrange(10):
@@ -1681,7 +1644,7 @@ class FieldTest(unittest.TestCase):
             counter = SequenceField()
             name = StringField()
 
-        self.db['mongoengine.counters'].really_drop()
+        self.db['mongoengine.counters'].drop()
         Person.drop_collection()
 
         for x in xrange(10):
@@ -1705,7 +1668,7 @@ class FieldTest(unittest.TestCase):
             counter = SequenceField()
             type = StringField()
 
-        self.db['mongoengine.counters'].really_drop()
+        self.db['mongoengine.counters'].drop()
         Animal.drop_collection()
 
         a = Animal(type="Boi")
@@ -1734,7 +1697,7 @@ class FieldTest(unittest.TestCase):
         class Person(Document):
             id = SequenceField(primary_key=True)
 
-        self.db['mongoengine.counters'].really_drop()
+        self.db['mongoengine.counters'].drop()
         Animal.drop_collection()
         Person.drop_collection()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from mongoengine import *
+from mongoengine import (
+    IntField, StringField, DateTimeField, FileField, ListField,
+    EmbeddedDocumentField, Document, EmbeddedDocument)
 
 
 class PickleEmbedded(EmbeddedDocument):

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -119,8 +119,12 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(len(self.Person.objects), 55)
         self.assertEqual("Person object", "%s" % self.Person.objects[0])
-        self.assertEqual("[<Person: Person object>, <Person: Person object>]",  "%s" % self.Person.objects[1:3])
-        self.assertEqual("[<Person: Person object>, <Person: Person object>]",  "%s" % self.Person.objects[51:53])
+        self.assertEqual(
+            "[<Person: Person object>, <Person: Person object>]",
+            "%s" % self.Person.objects[1:3])
+        self.assertEqual(
+            "[<Person: Person object>, <Person: Person object>]",
+            "%s" % self.Person.objects[51:53])
 
     def test_find_one(self):
         """Ensure that a query using find_one returns a valid result.
@@ -156,7 +160,9 @@ class QuerySetTest(unittest.TestCase):
         person = self.Person.objects.with_id(person1.id)
         self.assertEqual(person.name, "User A")
 
-        self.assertRaises(InvalidQueryError, self.Person.objects(name="User A").with_id, person1.id)
+        self.assertRaises(
+            InvalidQueryError,
+            self.Person.objects(name="User A").with_id, person1.id)
 
     def test_find_only_one(self):
         """Ensure that a query using ``get`` returns at most one result.
@@ -210,7 +216,7 @@ class QuerySetTest(unittest.TestCase):
         post1 = Post(comments=[comment1, comment2])
         post2 = Post(comments=[comment2, comment2])
         blog1 = Blog.objects.create(posts=[post1, post2])
-        blog2 = Blog.objects.create(posts=[post2, post1])
+        Blog.objects.create(posts=[post2, post1])
 
         blog = Blog.objects(posts__0__comments__0__name='testa').get()
         self.assertEqual(blog, blog1)
@@ -237,12 +243,14 @@ class QuerySetTest(unittest.TestCase):
                             name='Test User', write_options=write_options)
         author.save(write_options=write_options)
 
-        self.Person.objects.update(set__name='Ross', write_options=write_options)
+        self.Person.objects.update(set__name='Ross',
+                                   write_options=write_options)
 
         author = self.Person.objects.first()
         self.assertEquals(author.name, 'Ross')
 
-        self.Person.objects.update_one(set__name='Test User', write_options=write_options)
+        self.Person.objects.update_one(set__name='Test User',
+                                       write_options=write_options)
         author = self.Person.objects.first()
         self.assertEquals(author.name, 'Test User')
 
@@ -295,11 +303,11 @@ class QuerySetTest(unittest.TestCase):
 
         Blog.drop_collection()
 
-        blog1 = Blog.objects.create(posts=[post1, post2])
-        blog2 = Blog.objects.create(posts=[post2, post1])
+        Blog.objects.create(posts=[post1, post2])
+        Blog.objects.create(posts=[post2, post1])
 
         # Update only the first blog returned by the query
-        blog = Blog.objects().update_one(
+        Blog.objects().update_one(
             set__posts__1__comments__1__name="testc")
         testc_blogs = Blog.objects(posts__1__comments__1__name="testc")
         self.assertEqual(len(testc_blogs), 1)
@@ -404,7 +412,8 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost(title="ABC", comments=[c1, c2]).save()
 
-        BlogPost.objects(comments__by="joe").update(set__comments__S__votes=Vote(score=4))
+        BlogPost.objects(comments__by="joe") \
+                .update(set__comments__S__votes=Vote(score=4))
 
         post = BlogPost.objects.first()
         self.assertEquals(post.comments[0].by, 'joe')
@@ -497,7 +506,7 @@ class QuerySetTest(unittest.TestCase):
 
         Blog.drop_collection()
 
-        # Recreates the collection
+        # Recreates the collection
         self.assertEqual(0, Blog.objects.count())
 
         with query_counter() as q:
@@ -513,10 +522,10 @@ class QuerySetTest(unittest.TestCase):
                 blogs.append(Blog(title="post %s" % i, posts=[post1, post2]))
 
             Blog.objects.insert(blogs, load_bulk=False)
-            self.assertEqual(q, 1) # 1 for the insert
+            self.assertEqual(q, 1)  # 1 for the insert
 
             Blog.objects.insert(blogs)
-            self.assertEqual(q, 3) # 1 for insert, and 1 for in bulk fetch (3 in total)
+            self.assertEqual(q, 3)  # 1 insert, 1 for in bulk fetch (3 total)
 
         Blog.drop_collection()
 
@@ -589,10 +598,10 @@ class QuerySetTest(unittest.TestCase):
         self.Person(name='Person 2').save()
 
         queryset = self.Person.objects
-        self.assertEquals('[<Person: Person object>, <Person: Person object>]', repr(queryset))
+        self.assertEquals('[<Person: Person object>, <Person: Person object>]',
+                          repr(queryset))
         for person in queryset:
             self.assertEquals('.. queryset mid-iteration ..', repr(queryset))
-
 
     def test_regex_query_shortcuts(self):
         """Ensure that contains, startswith, endswith, etc work.
@@ -704,14 +713,14 @@ class QuerySetTest(unittest.TestCase):
                 return queryset(is_published=True)
 
         blog_post_1 = BlogPost(title="Blog Post #1",
-                               is_published = True,
-                               published_date=datetime(2010, 1, 5, 0, 0 ,0))
+                               is_published=True,
+                               published_date=datetime(2010, 1, 5, 0, 0, 0))
         blog_post_2 = BlogPost(title="Blog Post #2",
-                               is_published = True,
-                               published_date=datetime(2010, 1, 6, 0, 0 ,0))
+                               is_published=True,
+                               published_date=datetime(2010, 1, 6, 0, 0, 0))
         blog_post_3 = BlogPost(title="Blog Post #3",
-                               is_published = True,
-                               published_date=datetime(2010, 1, 7, 0, 0 ,0))
+                               is_published=True,
+                               published_date=datetime(2010, 1, 7, 0, 0, 0))
 
         blog_post_1.save()
         blog_post_2.save()
@@ -720,7 +729,7 @@ class QuerySetTest(unittest.TestCase):
         # find all published blog posts before 2010-01-07
         published_posts = BlogPost.published()
         published_posts = published_posts.filter(
-            published_date__lt=datetime(2010, 1, 7, 0, 0 ,0))
+            published_date__lt=datetime(2010, 1, 7, 0, 0, 0))
         self.assertEqual(published_posts.count(), 2)
 
         BlogPost.drop_collection()
@@ -811,7 +820,8 @@ class QuerySetTest(unittest.TestCase):
 
         post = BlogPost(content='Had a good coffee today...')
         post.author = User(name='Test User')
-        post.comments = [Comment(title='I aggree', text='Great post!'), Comment(title='Coffee', text='I hate coffee')]
+        post.comments = [Comment(title='I aggree', text='Great post!'),
+                         Comment(title='Coffee', text='I hate coffee')]
         post.save()
 
         obj = BlogPost.objects.only('author.name',).get()
@@ -856,7 +866,8 @@ class QuerySetTest(unittest.TestCase):
 
         post = BlogPost(content='Had a good coffee today...')
         post.author = User(name='Test User')
-        post.comments = [Comment(title='I aggree', text='Great post!'), Comment(title='Coffee', text='I hate coffee')]
+        post.comments = [Comment(title='I aggree', text='Great post!'),
+                         Comment(title='Coffee', text='I hate coffee')]
         post.save()
 
         obj = BlogPost.objects.exclude('author', 'comments.text').get()
@@ -881,7 +892,11 @@ class QuerySetTest(unittest.TestCase):
             attachments = ListField(EmbeddedDocumentField(Attachment))
 
         Email.drop_collection()
-        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email = Email(sender='me',
+                      to='you',
+                      subject='From Russia with Love',
+                      body='Hello!',
+                      content_type='text/plain')
         email.attachments = [
             Attachment(name='file1.doc', content='ABC'),
             Attachment(name='file2.doc', content='XYZ'),
@@ -902,7 +917,10 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(obj.body, None)
         self.assertEqual(obj.content_type, None)
 
-        obj = Email.objects.exclude('attachments.content').exclude('body').only('to', 'attachments.name').get()
+        obj = Email.objects.exclude('attachments.content') \
+                           .exclude('body') \
+                           .only('to', 'attachments.name') \
+                           .get()
         self.assertEqual(obj.attachments[0].name, 'file1.doc')
         self.assertEqual(obj.attachments[0].content, None)
         self.assertEqual(obj.sender, None)
@@ -924,10 +942,17 @@ class QuerySetTest(unittest.TestCase):
 
         Email.drop_collection()
 
-        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email = Email(sender='me',
+                      to='you',
+                      subject='From Russia with Love',
+                      body='Hello!',
+                      content_type='text/plain')
         email.save()
 
-        obj = Email.objects.exclude('content_type', 'body').only('to', 'body').all_fields().get()
+        obj = Email.objects.exclude('content_type', 'body') \
+                   .only('to', 'body') \
+                   .all_fields()\
+                   .get()
         self.assertEqual(obj.sender, 'me')
         self.assertEqual(obj.to, 'you')
         self.assertEqual(obj.subject, 'From Russia with Love')
@@ -944,7 +969,7 @@ class QuerySetTest(unittest.TestCase):
 
         Numbers.drop_collection()
 
-        numbers = Numbers(n=[0,1,2,3,4,5,-5,-4,-3,-2,-1])
+        numbers = Numbers(n=[0, 1, 2 ,3, 4, 5, -5, -4, -3, -2, -1])
         numbers.save()
 
         # first three
@@ -984,7 +1009,8 @@ class QuerySetTest(unittest.TestCase):
         Numbers.drop_collection()
 
         numbers = Numbers()
-        numbers.embedded = EmbeddedNumber(n=[0,1,2,3,4,5,-5,-4,-3,-2,-1])
+        numbers.embedded = EmbeddedNumber(
+            n=[0, 1, 2, 3, 4, 5, -5, -4, -3, -2, -1])
         numbers.save()
 
         # first three
@@ -1059,10 +1085,14 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
-        post1 = BlogPost(title='Test 1', publish_date=datetime(2010, 1, 8), published=False)
+        post1 = BlogPost(title='Test 1',
+                         publish_date=datetime(2010, 1, 8),
+                         published=False)
         post1.save()
 
-        post2 = BlogPost(title='Test 2', publish_date=datetime(2010, 1, 15), published=True)
+        post2 = BlogPost(title='Test 2',
+                         publish_date=datetime(2010, 1, 15),
+                         published=True)
         post2.save()
 
         post3 = BlogPost(title='Test 3', published=True)
@@ -1092,7 +1122,6 @@ class QuerySetTest(unittest.TestCase):
         posts = [post.id for post in q]
         published_posts = (post1, post2, post3, post5, post6)
         self.assertTrue(all(obj.id in posts for obj in published_posts))
-
 
         # Check Q object combination
         date = datetime(2010, 1, 10)
@@ -1408,7 +1437,6 @@ class QuerySetTest(unittest.TestCase):
         post.reload()
         self.assertEqual(post.tags, ["mongodb"])
 
-
         BlogPost.objects(slug="test").update(pull_all__tags=["mongodb", "code"])
         post.reload()
         self.assertEqual(post.tags, [])
@@ -1416,7 +1444,6 @@ class QuerySetTest(unittest.TestCase):
         BlogPost.objects(slug="test").update(__raw__={"$addToSet": {"tags": {"$each": ["code", "mongodb", "code"]}}})
         post.reload()
         self.assertEqual(post.tags, ["code", "mongodb"])
-
 
     def test_update_one_pop_generic_reference(self):
 
@@ -1633,30 +1660,30 @@ class QuerySetTest(unittest.TestCase):
         # Fri, 12 Feb 2010 14:36:00 -0600. Link ordering should
         # reflect order of insertion below, but is not influenced
         # by insertion order.
-        Link(title = "Google Buzz auto-followed a woman's abusive ex ...",
-             up_votes = 1079,
-             down_votes = 553,
-             submitted = now-timedelta(hours=4)).save()
-        Link(title = "We did it! Barbie is a computer engineer.",
-             up_votes = 481,
-             down_votes = 124,
-             submitted = now-timedelta(hours=2)).save()
-        Link(title = "This Is A Mosquito Getting Killed By A Laser",
-             up_votes = 1446,
-             down_votes = 530,
+        Link(title="Google Buzz auto-followed a woman's abusive ex ...",
+             up_votes=1079,
+             down_votes=553,
+             submitted=now - timedelta(hours=4)).save()
+        Link(title="We did it! Barbie is a computer engineer.",
+             up_votes=481,
+             down_votes=124,
+             submitted=now-timedelta(hours=2)).save()
+        Link(title="This Is A Mosquito Getting Killed By A Laser",
+             up_votes=1446,
+             down_votes=530,
              submitted=now-timedelta(hours=13)).save()
-        Link(title = "Arabic flashcards land physics student in jail.",
-             up_votes = 215,
-             down_votes = 105,
-             submitted = now-timedelta(hours=6)).save()
-        Link(title = "The Burger Lab: Presenting, the Flood Burger",
-             up_votes = 48,
-             down_votes = 17,
-             submitted = now-timedelta(hours=5)).save()
+        Link(title= "Arabic flashcards land physics student in jail.",
+             up_votes=215,
+             down_votes=105,
+             submitted=now - timedelta(hours=6)).save()
+        Link(title="The Burger Lab: Presenting, the Flood Burger",
+             up_votes=48,
+             down_votes=17,
+             submitted=now - timedelta(hours=5)).save()
         Link(title="How to see polarization with the naked eye",
-             up_votes = 74,
-             down_votes = 13,
-             submitted = now-timedelta(hours=10)).save()
+             up_votes=74,
+             down_votes=13,
+             submitted=now - timedelta(hours=10)).save()
 
         map_f = """
             function() {
@@ -1743,7 +1770,8 @@ class QuerySetTest(unittest.TestCase):
 
         def test_assertions(f):
             f = dict((key, int(val)) for key, val in f.items())
-            self.assertEqual(set(['music', 'film', 'actors', 'watch']), set(f.keys()))
+            self.assertEqual(set(['music', 'film', 'actors', 'watch']),
+                             set(f.keys()))
             self.assertEqual(f['music'], 3)
             self.assertEqual(f['actors'], 2)
             self.assertEqual(f['watch'], 2)
@@ -1763,7 +1791,8 @@ class QuerySetTest(unittest.TestCase):
             self.assertEqual(f['watch'], 1)
 
         exec_js = BlogPost.objects(hits__gt=1).item_frequencies('tags')
-        map_reduce = BlogPost.objects(hits__gt=1).item_frequencies('tags', map_reduce=True)
+        map_reduce = BlogPost.objects(hits__gt=1)\
+                             .item_frequencies('tags', map_reduce=True)
         test_assertions(exec_js)
         test_assertions(map_reduce)
 
@@ -1775,7 +1804,9 @@ class QuerySetTest(unittest.TestCase):
             self.assertAlmostEqual(f['film'], 1.0/8.0)
 
         exec_js = BlogPost.objects.item_frequencies('tags', normalize=True)
-        map_reduce = BlogPost.objects.item_frequencies('tags', normalize=True, map_reduce=True)
+        map_reduce = BlogPost.objects.item_frequencies('tags',
+                                                       normalize=True,
+                                                       map_reduce=True)
         test_assertions(exec_js)
         test_assertions(map_reduce)
 
@@ -1817,15 +1848,16 @@ class QuerySetTest(unittest.TestCase):
         doc.phone = Phone(number='62-3332-1656')
         doc.save()
 
-
         def test_assertions(f):
             f = dict((key, int(val)) for key, val in f.items())
-            self.assertEqual(set(['62-3331-1656', '62-3332-1656']), set(f.keys()))
+            self.assertEqual(set(['62-3331-1656', '62-3332-1656']),
+                             set(f.keys()))
             self.assertEqual(f['62-3331-1656'], 2)
             self.assertEqual(f['62-3332-1656'], 1)
 
         exec_js = Person.objects.item_frequencies('phone.number')
-        map_reduce = Person.objects.item_frequencies('phone.number', map_reduce=True)
+        map_reduce = Person.objects.item_frequencies('phone.number',
+                                                     map_reduce=True)
         test_assertions(exec_js)
         test_assertions(map_reduce)
 
@@ -1835,8 +1867,10 @@ class QuerySetTest(unittest.TestCase):
             self.assertEqual(set(['62-3331-1656']), set(f.keys()))
             self.assertEqual(f['62-3331-1656'], 2)
 
-        exec_js = Person.objects(phone__number='62-3331-1656').item_frequencies('phone.number')
-        map_reduce = Person.objects(phone__number='62-3331-1656').item_frequencies('phone.number', map_reduce=True)
+        exec_js = Person.objects(phone__number='62-3331-1656') \
+                        .item_frequencies('phone.number')
+        map_reduce = Person.objects(phone__number='62-3331-1656') \
+                           .item_frequencies('phone.number', map_reduce=True)
         test_assertions(exec_js)
         test_assertions(map_reduce)
 
@@ -1845,8 +1879,11 @@ class QuerySetTest(unittest.TestCase):
             self.assertEqual(f['62-3331-1656'], 2.0/3.0)
             self.assertEqual(f['62-3332-1656'], 1.0/3.0)
 
-        exec_js = Person.objects.item_frequencies('phone.number', normalize=True)
-        map_reduce = Person.objects.item_frequencies('phone.number', normalize=True, map_reduce=True)
+        exec_js = Person.objects.item_frequencies('phone.number',
+                                                  normalize=True)
+        map_reduce = Person.objects.item_frequencies('phone.number',
+                                                     normalize=True,
+                                                     map_reduce=True)
         test_assertions(exec_js)
         test_assertions(map_reduce)
 
@@ -1866,7 +1903,6 @@ class QuerySetTest(unittest.TestCase):
         freq = Person.objects.item_frequencies('city', normalize=True)
         self.assertEquals(freq, {'CRB': 0.5, None: 0.5})
 
-
         freq = Person.objects.item_frequencies('city', map_reduce=True)
         self.assertEquals(freq, {'CRB': 1.0, None: 1.0})
         freq = Person.objects.item_frequencies('city', normalize=True, map_reduce=True)
@@ -1882,7 +1918,6 @@ class QuerySetTest(unittest.TestCase):
         class Person(Document):
             data = EmbeddedDocumentField(Data, required=True)
             extra = EmbeddedDocumentField(Extra)
-
 
         Person.drop_collection()
 
@@ -1911,7 +1946,7 @@ class QuerySetTest(unittest.TestCase):
         for i, age in enumerate(ages):
             self.Person(name='test%s' % i, age=age).save()
 
-        avg = float(sum(ages)) / (len(ages) + 1) # take into account the 0
+        avg = float(sum(ages)) / (len(ages) + 1)  # take into account the 0
         self.assertAlmostEqual(int(self.Person.objects.average('age')), avg)
 
         self.Person(name='ageless person').save()
@@ -2006,7 +2041,6 @@ class QuerySetTest(unittest.TestCase):
             comments = ListField(EmbeddedDocumentField(Comment),
                                  db_field='postComments')
 
-
         BlogPost.drop_collection()
 
         data = {'title': 'Post 1', 'comments': [Comment(content='test')]}
@@ -2036,7 +2070,7 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
-        data = { 'title':'Post 1' }
+        data = {'title':'Post 1'}
         post = BlogPost(**data)
         post.save()
 
@@ -2242,21 +2276,19 @@ class QuerySetTest(unittest.TestCase):
         required_version = tuple("1.9.0".split("."))
         if server_version >= required_version:
             polygon = [
-                (41.912114,-87.694445),
-                (41.919395,-87.69084),
-                (41.927186,-87.681742),
-                (41.911731,-87.654276),
-                (41.898061,-87.656164),
-            ]
+                (41.912114, -87.694445),
+                (41.919395, -87.69084),
+                (41.927186, -87.681742),
+                (41.911731, -87.654276),
+                (41.898061, -87.656164)]
             events = Event.objects(location__within_polygon=polygon)
             self.assertEqual(events.count(), 1)
             self.assertEqual(events[0].id, event1.id)
 
             polygon2 = [
-                (54.033586,-1.742249),
-                (52.792797,-1.225891),
-                (53.389881,-4.40094)
-            ]
+                (54.033586, -1.742249),
+                (52.792797, -1.225891),
+                (53.389881, -4.40094)]
             events = Event.objects(location__within_polygon=polygon2)
             self.assertEqual(events.count(), 0)
 
@@ -2274,12 +2306,12 @@ class QuerySetTest(unittest.TestCase):
 
         # These points are one degree apart, which (according to Google Maps)
         # is about 110 km apart at this place on the Earth.
-        north_point = Point(location=[-122, 38]) # Near Concord, CA
-        south_point = Point(location=[-122, 37]) # Near Santa Cruz, CA
+        north_point = Point(location=[-122, 38])  # Near Concord, CA
+        south_point = Point(location=[-122, 37])  # Near Santa Cruz, CA
         north_point.save()
         south_point.save()
 
-        earth_radius = 6378.009; # in km (needs to be a float for dividing by)
+        earth_radius = 6378.009  # in km (needs to be a float for dividing by)
 
         # Finds both points because they are within 60 km of the reference
         # point equidistant between them.
@@ -2288,8 +2320,7 @@ class QuerySetTest(unittest.TestCase):
 
         # Same behavior for _within_spherical_distance
         points = Point.objects(
-            location__within_spherical_distance=[[-122, 37.5], 60/earth_radius]
-        );
+            location__within_spherical_distance=[[-122, 37.5], 60/earth_radius])
         self.assertEqual(points.count(), 2)
 
         # Finds both points, but orders the north point first because it's
@@ -2309,8 +2340,7 @@ class QuerySetTest(unittest.TestCase):
         # Finds only one point because only the first point is within 60km of
         # the reference point to the south.
         points = Point.objects(
-            location__within_spherical_distance=[[-122, 36.5], 60/earth_radius]
-        );
+            location__within_spherical_distance=[[-122, 36.5], 60/earth_radius])
         self.assertEqual(points.count(), 1)
         self.assertEqual(points[0].id, south_point.id)
 
@@ -2567,8 +2597,8 @@ class QuerySetTest(unittest.TestCase):
         n2 = Number.objects.create(n=2)
         n1 = Number.objects.create(n=1)
 
-        self.assertEqual(list(Number.objects), [n2,n1])
-        self.assertEqual(list(Number.objects.order_by('n')), [n1,n2])
+        self.assertEqual(list(Number.objects), [n2, n1])
+        self.assertEqual(list(Number.objects.order_by('n')), [n1, n2])
 
         Number.drop_collection()
 
@@ -2591,11 +2621,9 @@ class QuerySetTest(unittest.TestCase):
         self.assertEquals([1, 2, 3], numbers)
         Number.drop_collection()
 
-
     def test_where(self):
         """Ensure that where clauses work.
         """
-
         class IntPair(Document):
             fielda = IntField()
             fieldb = IntField()
@@ -2610,7 +2638,8 @@ class QuerySetTest(unittest.TestCase):
         c.save()
 
         query = IntPair.objects.where('this[~fielda] >= this[~fieldb]')
-        self.assertEqual('this["fielda"] >= this["fieldb"]', query._where_clause)
+        self.assertEqual('this["fielda"] >= this["fieldb"]',
+                         query._where_clause)
         results = list(query)
         self.assertEqual(2, len(results))
         self.assertTrue(a in results)
@@ -2621,8 +2650,11 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(1, len(results))
         self.assertTrue(a in results)
 
-        query = IntPair.objects.where('function() { return this[~fielda] >= this[~fieldb] }')
-        self.assertEqual('function() { return this["fielda"] >= this["fieldb"] }', query._where_clause)
+        query = IntPair.objects.where(
+            'function() { return this[~fielda] >= this[~fieldb] }')
+        self.assertEqual(
+            'function() { return this["fielda"] >= this["fieldb"] }',
+            query._where_clause)
         results = list(query)
         self.assertEqual(2, len(results))
         self.assertTrue(a in results)
@@ -2736,8 +2768,10 @@ class QuerySetTest(unittest.TestCase):
                locale=Locale(city="Brasilia", country="Brazil")).save()
 
         self.assertEqual(
-            list(Person.objects.order_by('profile__age').scalar('profile__name')),
-            [u'Wilson Jr', u'Gabriel Falcao', u'Lincoln de souza', u'Walter cruz'])
+            list(Person.objects.order_by('profile__age')
+                       .scalar('profile__name')),
+            [u'Wilson Jr', u'Gabriel Falcao',
+             u'Lincoln de souza', u'Walter cruz'])
 
         ulist = list(Person.objects.order_by('locale.city')
                      .scalar('profile__name', 'profile__age', 'locale__city'))
@@ -2758,7 +2792,6 @@ class QuerySetTest(unittest.TestCase):
 
         ulist = list(Person.objects.scalar('name', 'rating'))
         self.assertEqual(ulist, [(u'Wilson Jr', Decimal('1.0'))])
-
 
     def test_scalar_reference_field(self):
         class State(Document):
@@ -2880,17 +2913,30 @@ class QuerySetTest(unittest.TestCase):
             self.Person(name='A%s' % i, age=i).save()
 
         self.assertEqual(len(self.Person.objects.scalar('name')), 55)
-        self.assertEqual("A0", "%s" % self.Person.objects.order_by('name').scalar('name').first())
-        self.assertEqual("A0", "%s" % self.Person.objects.scalar('name').order_by('name')[0])
-        self.assertEqual("[u'A1', u'A2']",  "%s" % self.Person.objects.order_by('age').scalar('name')[1:3])
-        self.assertEqual("[u'A51', u'A52']",  "%s" % self.Person.objects.order_by('age').scalar('name')[51:53])
+        self.assertEqual(
+            "A0",
+            "%s" % self.Person.objects.order_by('name').scalar('name').first())
+        self.assertEqual(
+            "A0",
+            "%s" % self.Person.objects.scalar('name').order_by('name')[0])
+        self.assertEqual(
+            "[u'A1', u'A2']",
+            "%s" % self.Person.objects.order_by('age').scalar('name')[1:3])
+        self.assertEqual(
+            "[u'A51', u'A52']",
+            "%s" % self.Person.objects.order_by('age').scalar('name')[51:53])
 
         # with_id and in_bulk
         person = self.Person.objects.order_by('name').first()
-        self.assertEqual("A0", "%s" % self.Person.objects.scalar('name').with_id(person.id))
+        self.assertEqual(
+            "A0",
+            "%s" % self.Person.objects.scalar('name').with_id(person.id))
 
         pks = self.Person.objects.order_by('age').scalar('pk')[1:3]
-        self.assertEqual("[u'A1', u'A2']",  "%s" % sorted(self.Person.objects.scalar('name').in_bulk(list(pks)).values()))
+        self.assertEqual(
+            "[u'A1', u'A2']",
+            "%s" % sorted(
+                self.Person.objects.scalar('name').in_bulk(list(pks)).values()))
 
     def test_batch_size(self):
         """Ensure that batch_size works."""
@@ -3084,13 +3130,12 @@ class QTest(unittest.TestCase):
         conditions = [
             {'x': {'$gt': 0}, 'y': True},
             {'x': {'$gt': 0}, 'y': {'$exists': False}},
-            {'x': {'$lt': 100}, 'y':False},
+            {'x': {'$lt': 100}, 'y': False},
             {'x': {'$lt': 100}, 'y': {'$exists': False}},
         ]
         self.assertEqual(len(conditions), len(query['$or']))
         for condition in conditions:
             self.assertTrue(condition in query['$or'])
-
 
     def test_q_clone(self):
 
@@ -3114,6 +3159,7 @@ class QTest(unittest.TestCase):
         test2.filter(x=6)
         self.assertEqual(test2.count(), 1)
         self.assertEqual(test.count(), 3)
+
 
 class QueryFieldListTest(unittest.TestCase):
     def test_empty(self):
@@ -3153,19 +3199,22 @@ class QueryFieldListTest(unittest.TestCase):
 
     def test_always_include(self):
         q = QueryFieldList(always_include=['x', 'y'])
-        q += QueryFieldList(fields=['a', 'b', 'x'], value=QueryFieldList.EXCLUDE)
+        q += QueryFieldList(fields=['a', 'b', 'x'],
+                            value=QueryFieldList.EXCLUDE)
         q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
         self.assertEqual(q.as_dict(), {'x': True, 'y': True, 'c': True})
 
     def test_reset(self):
         q = QueryFieldList(always_include=['x', 'y'])
-        q += QueryFieldList(fields=['a', 'b', 'x'], value=QueryFieldList.EXCLUDE)
+        q += QueryFieldList(fields=['a', 'b', 'x'],
+                            value=QueryFieldList.EXCLUDE)
         q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
         self.assertEqual(q.as_dict(), {'x': True, 'y': True, 'c': True})
         q.reset()
         self.assertFalse(q)
         q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
-        self.assertEqual(q.as_dict(), {'x': True, 'y': True, 'b': True, 'c': True})
+        self.assertEqual(q.as_dict(),
+                         {'x': True, 'y': True, 'b': True, 'c': True})
 
     def test_using_a_slice(self):
         q = QueryFieldList()
@@ -3188,15 +3237,16 @@ class QueryFieldListTest(unittest.TestCase):
 
         Bar.drop_collection()
 
-        b1 = Bar(foo=[Foo(shape= "square", color ="purple", thick = False),
-                      Foo(shape= "circle", color ="red", thick = True)])
+        b1 = Bar(foo=[Foo(shape="square", color="purple", thick=False),
+                      Foo(shape="circle", color="red", thick=True)])
         b1.save()
 
-        b2 = Bar(foo=[Foo(shape= "square", color ="red", thick = True),
-                      Foo(shape= "circle", color ="purple", thick = False)])
+        b2 = Bar(foo=[Foo(shape="square", color="red", thick=True),
+                      Foo(shape="circle", color="purple", thick=False)])
         b2.save()
 
-        ak = list(Bar.objects(foo__match={'shape': "square", "color": "purple"}))
+        ak = list(Bar.objects(
+            foo__match={'shape': "square", "color": "purple"}))
         self.assertEqual([b1], ak)
 
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -256,12 +256,12 @@ class QuerySetTest(unittest.TestCase):
                                    write_options=write_options)
 
         author = self.Person.objects.first()
-        self.assertEquals(author.name, 'Ross')
+        self.assertEqual(author.name, 'Ross')
 
         self.Person.objects.update_one(set__name='Test User',
                                        write_options=write_options)
         author = self.Person.objects.first()
-        self.assertEquals(author.name, 'Test User')
+        self.assertEqual(author.name, 'Test User')
 
     def test_update_update_has_a_value(self):
         """Test to ensure that update is passed a value to update to"""
@@ -350,8 +350,8 @@ class QuerySetTest(unittest.TestCase):
         BlogPost.objects(comments__by="jane").update(inc__comments__S__votes=1)
 
         post = BlogPost.objects.first()
-        self.assertEquals(post.comments[1].by, 'jane')
-        self.assertEquals(post.comments[1].votes, 8)
+        self.assertEqual(post.comments[1].by, 'jane')
+        self.assertEqual(post.comments[1].votes, 8)
 
         # Currently the $ operator only applies to the first matched item in
         # the query
@@ -364,7 +364,7 @@ class QuerySetTest(unittest.TestCase):
         Simple.objects(x=2).update(inc__x__S=1)
 
         simple = Simple.objects.first()
-        self.assertEquals(simple.x, [1, 3, 3, 2])
+        self.assertEqual(simple.x, [1, 3, 3, 2])
         Simple.drop_collection()
 
         # You can set multiples
@@ -376,10 +376,10 @@ class QuerySetTest(unittest.TestCase):
         Simple.objects(x=3).update(set__x__S=0)
 
         s = Simple.objects()
-        self.assertEquals(s[0].x, [1, 2, 0, 4])
-        self.assertEquals(s[1].x, [2, 0, 4, 5])
-        self.assertEquals(s[2].x, [0, 4, 5, 6])
-        self.assertEquals(s[3].x, [4, 5, 6, 7])
+        self.assertEqual(s[0].x, [1, 2, 0, 4])
+        self.assertEqual(s[1].x, [2, 0, 4, 5])
+        self.assertEqual(s[2].x, [0, 4, 5, 6])
+        self.assertEqual(s[3].x, [4, 5, 6, 7])
 
         # Using "$unset" with an expression like this "array.$" will result in
         # the array item becoming None, not being removed.
@@ -387,14 +387,14 @@ class QuerySetTest(unittest.TestCase):
         Simple(x=[1, 2, 3, 4, 3, 2, 3, 4]).save()
         Simple.objects(x=3).update(unset__x__S=1)
         simple = Simple.objects.first()
-        self.assertEquals(simple.x, [1, 2, None, 4, 3, 2, 3, 4])
+        self.assertEqual(simple.x, [1, 2, None, 4, 3, 2, 3, 4])
 
         # Nested updates arent supported yet..
         def update_nested():
             Simple.drop_collection()
             Simple(x=[{'test': [1, 2, 3, 4]}]).save()
             Simple.objects(x__test=2).update(set__x__S__test__S=3)
-            self.assertEquals(simple.x, [1, 2, 3, 4])
+            self.assertEqual(simple.x, [1, 2, 3, 4])
 
         self.assertRaises(OperationError, update_nested)
         Simple.drop_collection()
@@ -425,8 +425,8 @@ class QuerySetTest(unittest.TestCase):
                 .update(set__comments__S__votes=Vote(score=4))
 
         post = BlogPost.objects.first()
-        self.assertEquals(post.comments[0].by, 'joe')
-        self.assertEquals(post.comments[0].votes.score, 4)
+        self.assertEqual(post.comments[0].by, 'joe')
+        self.assertEqual(post.comments[0].votes.score, 4)
 
     def test_mapfield_update(self):
         """Ensure that the MapField can be updated."""
@@ -580,7 +580,7 @@ class QuerySetTest(unittest.TestCase):
         Blog.drop_collection()
         blog1 = Blog(title="code", posts=[post1, post2])
         obj_id = Blog.objects.insert(blog1, load_bulk=False)
-        self.assertEquals(obj_id.__class__.__name__, 'ObjectId')
+        self.assertEqual(obj_id.__class__.__name__, 'ObjectId')
 
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.
@@ -607,10 +607,10 @@ class QuerySetTest(unittest.TestCase):
         self.Person(name='Person 2').save()
 
         queryset = self.Person.objects
-        self.assertEquals('[<Person: Person object>, <Person: Person object>]',
+        self.assertEqual('[<Person: Person object>, <Person: Person object>]',
                           repr(queryset))
         for person in queryset:
-            self.assertEquals('.. queryset mid-iteration ..', repr(queryset))
+            self.assertEqual('.. queryset mid-iteration ..', repr(queryset))
 
     def test_regex_query_shortcuts(self):
         """Ensure that contains, startswith, endswith, etc work.
@@ -985,27 +985,27 @@ class QuerySetTest(unittest.TestCase):
 
         # first three
         numbers = Numbers.objects.fields(slice__n=3).get()
-        self.assertEquals(numbers.n, [0, 1, 2])
+        self.assertEqual(numbers.n, [0, 1, 2])
 
         # last three
         numbers = Numbers.objects.fields(slice__n=-3).get()
-        self.assertEquals(numbers.n, [-3, -2, -1])
+        self.assertEqual(numbers.n, [-3, -2, -1])
 
         # skip 2, limit 3
         numbers = Numbers.objects.fields(slice__n=[2, 3]).get()
-        self.assertEquals(numbers.n, [2, 3, 4])
+        self.assertEqual(numbers.n, [2, 3, 4])
 
         # skip to fifth from last, limit 4
         numbers = Numbers.objects.fields(slice__n=[-5, 4]).get()
-        self.assertEquals(numbers.n, [-5, -4, -3, -2])
+        self.assertEqual(numbers.n, [-5, -4, -3, -2])
 
         # skip to fifth from last, limit 10
         numbers = Numbers.objects.fields(slice__n=[-5, 10]).get()
-        self.assertEquals(numbers.n, [-5, -4, -3, -2, -1])
+        self.assertEqual(numbers.n, [-5, -4, -3, -2, -1])
 
         # skip to fifth from last, limit 10 dict method
         numbers = Numbers.objects.fields(n={"$slice": [-5, 10]}).get()
-        self.assertEquals(numbers.n, [-5, -4, -3, -2, -1])
+        self.assertEqual(numbers.n, [-5, -4, -3, -2, -1])
 
     def test_slicing_nested_fields(self):
         """Ensure that query slicing an embedded array works.
@@ -1026,27 +1026,27 @@ class QuerySetTest(unittest.TestCase):
 
         # first three
         numbers = Numbers.objects.fields(slice__embedded__n=3).get()
-        self.assertEquals(numbers.embedded.n, [0, 1, 2])
+        self.assertEqual(numbers.embedded.n, [0, 1, 2])
 
         # last three
         numbers = Numbers.objects.fields(slice__embedded__n=-3).get()
-        self.assertEquals(numbers.embedded.n, [-3, -2, -1])
+        self.assertEqual(numbers.embedded.n, [-3, -2, -1])
 
         # skip 2, limit 3
         numbers = Numbers.objects.fields(slice__embedded__n=[2, 3]).get()
-        self.assertEquals(numbers.embedded.n, [2, 3, 4])
+        self.assertEqual(numbers.embedded.n, [2, 3, 4])
 
         # skip to fifth from last, limit 4
         numbers = Numbers.objects.fields(slice__embedded__n=[-5, 4]).get()
-        self.assertEquals(numbers.embedded.n, [-5, -4, -3, -2])
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2])
 
         # skip to fifth from last, limit 10
         numbers = Numbers.objects.fields(slice__embedded__n=[-5, 10]).get()
-        self.assertEquals(numbers.embedded.n, [-5, -4, -3, -2, -1])
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2, -1])
 
         # skip to fifth from last, limit 10 dict method
         numbers = Numbers.objects.fields(embedded__n={"$slice": [-5, 10]}).get()
-        self.assertEquals(numbers.embedded.n, [-5, -4, -3, -2, -1])
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2, -1])
 
     def test_find_embedded(self):
         """Ensure that an embedded document is properly returned from a query.
@@ -1290,7 +1290,7 @@ class QuerySetTest(unittest.TestCase):
         # Test template style
         code = "{{~comments.content}}"
         sub_code = BlogPost.objects._sub_js_fields(code)
-        self.assertEquals("cmnts.body", sub_code)
+        self.assertEqual("cmnts.body", sub_code)
 
         BlogPost.drop_collection()
 
@@ -1515,7 +1515,7 @@ class QuerySetTest(unittest.TestCase):
 
         BlogPost.objects(slug="test-2").update_one(set__tags__0__name="python")
         post.reload()
-        self.assertEquals(post.tags[0].name, 'python')
+        self.assertEqual(post.tags[0].name, 'python')
 
         BlogPost.objects(slug="test-2").update_one(pop__tags=-1)
         post.reload()
@@ -1914,15 +1914,15 @@ class QuerySetTest(unittest.TestCase):
         Person(name="Wilson Jr").save()
 
         freq = Person.objects.item_frequencies('city')
-        self.assertEquals(freq, {'CRB': 1.0, None: 1.0})
+        self.assertEqual(freq, {'CRB': 1.0, None: 1.0})
         freq = Person.objects.item_frequencies('city', normalize=True)
-        self.assertEquals(freq, {'CRB': 0.5, None: 0.5})
+        self.assertEqual(freq, {'CRB': 0.5, None: 0.5})
 
         freq = Person.objects.item_frequencies('city', map_reduce=True)
-        self.assertEquals(freq, {'CRB': 1.0, None: 1.0})
+        self.assertEqual(freq, {'CRB': 1.0, None: 1.0})
         freq = Person.objects \
                      .item_frequencies('city', normalize=True, map_reduce=True)
-        self.assertEquals(freq, {'CRB': 0.5, None: 0.5})
+        self.assertEqual(freq, {'CRB': 0.5, None: 0.5})
 
     def test_item_frequencies_with_null_embedded(self):
         class Data(EmbeddedDocument):
@@ -1947,10 +1947,10 @@ class QuerySetTest(unittest.TestCase):
         p.save()
 
         ot = Person.objects.item_frequencies('extra.tag', map_reduce=False)
-        self.assertEquals(ot, {None: 1.0, u'friend': 1.0})
+        self.assertEqual(ot, {None: 1.0, 'friend': 1.0})
 
         ot = Person.objects.item_frequencies('extra.tag', map_reduce=True)
-        self.assertEquals(ot, {None: 1.0, u'friend': 1.0})
+        self.assertEqual(ot, {None: 1.0, 'friend': 1.0})
 
     def test_average(self):
         """Ensure that field can be averaged correctly.
@@ -2010,7 +2010,7 @@ class QuerySetTest(unittest.TestCase):
         foo = Foo(bar=bar)
         foo.save()
 
-        self.assertEquals(Foo.objects.distinct("bar"), [bar])
+        self.assertEqual(Foo.objects.distinct("bar"), [bar])
 
     def test_custom_manager(self):
         """Ensure that custom QuerySetManager instances work as expected.
@@ -2425,8 +2425,8 @@ class QuerySetTest(unittest.TestCase):
 
         Post().save()
         Post(is_published=True).save()
-        self.assertEquals(Post.objects.count(), 2)
-        self.assertEquals(Post.published.count(), 1)
+        self.assertEqual(Post.objects.count(), 2)
+        self.assertEqual(Post.published.count(), 1)
 
         Post.drop_collection()
 
@@ -2632,10 +2632,10 @@ class QuerySetTest(unittest.TestCase):
         Number(n=3).save()
 
         numbers = [n.n for n in Number.objects.order_by('-n')]
-        self.assertEquals([3, 2, 1], numbers)
+        self.assertEqual([3, 2, 1], numbers)
 
         numbers = [n.n for n in Number.objects.order_by('+n')]
-        self.assertEquals([1, 2, 3], numbers)
+        self.assertEqual([1, 2, 3], numbers)
         Number.drop_collection()
 
     def test_where(self):

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -78,7 +78,7 @@ class QuerySetTest(unittest.TestCase):
         # Use a query to filter the people found to just person1
         people = self.Person.objects(age=20)
         self.assertEqual(len(people), 1)
-        person = people.next()
+        person = next(people)
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
 
@@ -121,7 +121,7 @@ class QuerySetTest(unittest.TestCase):
 
         # Test larger slice __repr__
         self.Person.objects.delete()
-        for i in xrange(55):
+        for i in range(55):
             self.Person(name='A%s' % i, age=i).save()
 
         self.assertEqual(len(self.Person.objects), 55)
@@ -525,7 +525,7 @@ class QuerySetTest(unittest.TestCase):
             post2 = Post(comments=[comment2, comment2])
 
             blogs = []
-            for i in xrange(1, 100):
+            for i in range(1, 100):
                 blogs.append(Blog(title="post %s" % i, posts=[post1, post2]))
 
             Blog.objects.insert(blogs, load_bulk=False)
@@ -1599,10 +1599,10 @@ class QuerySetTest(unittest.TestCase):
         results = list(results)
         self.assertEqual(len(results), 4)
 
-        music = filter(lambda r: r.key == "music", results)[0]
+        music = [r for r in results if r.key == "music"][0]
         self.assertEqual(music.value, 2)
 
-        film = filter(lambda r: r.key == "film", results)[0]
+        film = [r for r in results if r.key == "film"][0]
         self.assertEqual(film.value, 3)
 
         BlogPost.drop_collection()
@@ -2520,7 +2520,7 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
-        for i in xrange(1, 101):
+        for i in range(1, 101):
             t = Number(n=i)
             t.save()
 
@@ -2547,7 +2547,7 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
-        for i in xrange(1, 101):
+        for i in range(1, 101):
             t = Number(n=i)
             t.save()
 
@@ -2568,7 +2568,7 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
-        for i in xrange(1, 101):
+        for i in range(1, 101):
             t = Number(n=i)
             t.save()
 
@@ -2908,7 +2908,7 @@ class QuerySetTest(unittest.TestCase):
         # Use a query to filter the people found to just person1
         people = self.Person.objects(age=20).scalar('name')
         self.assertEqual(len(people), 1)
-        person = people.next()
+        person = next(people)
         self.assertEqual(person, "User A")
 
         # Test limit
@@ -2950,7 +2950,7 @@ class QuerySetTest(unittest.TestCase):
 
         # Test larger slice __repr__
         self.Person.objects.delete()
-        for i in xrange(55):
+        for i in range(55):
             self.Person(name='A%s' % i, age=i).save()
 
         self.assertEqual(len(self.Person.objects.scalar('name')), 55)
@@ -3022,7 +3022,7 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
-        for i in xrange(1, 101):
+        for i in range(1, 101):
             t = Number(n=i)
             t.save()
 
@@ -3145,7 +3145,7 @@ class QTest(unittest.TestCase):
         q2 = (Q(x__lt=100) | Q(y=True))
         query = (q1 & q2).to_query(TestDoc)
 
-        self.assertEqual(['$or'], query.keys())
+        self.assertEqual(['$or'], list(query.keys()))
         conditions = [
             {'x': {'$lt': 100, '$gt': 0}},
             {'x': {'$lt': 100, '$exists': False}},
@@ -3167,7 +3167,7 @@ class QTest(unittest.TestCase):
         q2 = (Q(x__lt=100) & (Q(y=False) | Q(y__exists=False)))
         query = (q1 | q2).to_query(TestDoc)
 
-        self.assertEqual(['$or'], query.keys())
+        self.assertEqual(['$or'], list(query.keys()))
         conditions = [
             {'x': {'$gt': 0}, 'y': True},
             {'x': {'$gt': 0}, 'y': {'$exists': False}},
@@ -3184,7 +3184,7 @@ class QTest(unittest.TestCase):
             x = IntField()
 
         TestDoc.drop_collection()
-        for i in xrange(1, 101):
+        for i in range(1, 101):
             t = TestDoc(x=i)
             t.save()
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2497,6 +2497,46 @@ class QuerySetTest(unittest.TestCase):
 
         Number.drop_collection()
 
+    def test_modify_evaluated_query_with_limit(self):
+        class Number(Document):
+            n = IntField()
+
+        Number.drop_collection()
+
+        for i in xrange(1, 101):
+            t = Number(n=i)
+            t.save()
+
+        test = Number.objects
+        self.assertEqual(test.count(), 100)
+
+        test = test.filter(n__gt=11)
+        self.assertEqual(test.count(), 89)
+
+        test = test.limit(10)
+        self.assertEqual(test.count(), 10)
+
+        Number.drop_collection()
+
+    def test_modify_evaulated_query_with_skip(self):
+        class Number(Document):
+            n = IntField()
+
+        Number.drop_collection()
+
+        for i in xrange(1, 101):
+            t = Number(n=i)
+            t.save()
+
+        test = Number.objects
+
+        self.assertEqual(test[0].n, 1)
+
+        test.skip(5)
+        self.assertEqual(test[0].n, 6)
+
+        Number.drop_collection()
+
     def test_unset_reference(self):
         class Comment(Document):
             text = StringField()

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2864,6 +2864,19 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(plist[1], (20, False))
         self.assertEqual(plist[2], (30, True))
 
+    def test_scalar_primary_key(self):
+
+        class SettingValue(Document):
+            key = StringField(primary_key=True)
+            value = StringField()
+
+        SettingValue.drop_collection()
+        s = SettingValue(key="test", value="test value")
+        s.save()
+
+        val = SettingValue.objects.scalar('key', 'value')
+        self.assertEqual(list(val), [('test', 'test value')])
+
     def test_scalar_cursor_behaviour(self):
         """Ensure that a query returns a valid set of results.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -2877,6 +2877,19 @@ class QuerySetTest(unittest.TestCase):
         val = SettingValue.objects.scalar('key', 'value')
         self.assertEqual(list(val), [('test', 'test value')])
 
+    def test_scalar_with_db_field_mapping(self):
+
+        class SettingValue(Document):
+            key = StringField(db_field='k')
+            value = StringField()
+
+        SettingValue.drop_collection()
+        s = SettingValue(key="test", value="test value")
+        s.save()
+
+        val = SettingValue.objects.scalar('key', 'value')
+        self.assertEqual(list(val), [('test', 'test value')])
+
     def test_scalar_cursor_behaviour(self):
         """Ensure that a query returns a valid set of results.
         """

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 import pymongo
+import six
 from bson import ObjectId
 from datetime import datetime, timedelta
 
@@ -69,7 +70,8 @@ class QuerySetTest(unittest.TestCase):
         self.assertEqual(len(people), 2)
         results = list(people)
         self.assertTrue(isinstance(results[0], self.Person))
-        self.assertTrue(isinstance(results[0].id, (ObjectId, str, unicode)))
+        self.assertTrue(
+            isinstance(results[0].id, six.string_types + (ObjectId,)))
         self.assertEqual(results[0].name, "User A")
         self.assertEqual(results[0].age, 20)
         self.assertEqual(results[1].name, "User B")
@@ -2211,12 +2213,13 @@ class QuerySetTest(unittest.TestCase):
     def test_geospatial_operators(self):
         """Ensure that geospatial queries are working.
         """
+        @six.python_2_unicode_compatible
         class Event(Document):
             title = StringField()
             date = DateTimeField()
             location = GeoPointField()
 
-            def __unicode__(self):
+            def __str__(self):
                 return self.title
 
         Event.drop_collection()
@@ -2961,10 +2964,10 @@ class QuerySetTest(unittest.TestCase):
             "A0",
             "%s" % self.Person.objects.scalar('name').order_by('name')[0])
         self.assertEqual(
-            "[u'A1', u'A2']",
+            six.text_type([u'A1', u'A2']),
             "%s" % self.Person.objects.order_by('age').scalar('name')[1:3])
         self.assertEqual(
-            "[u'A51', u'A52']",
+            six.text_type([u'A51', u'A52']),
             "%s" % self.Person.objects.order_by('age').scalar('name')[51:53])
 
         # with_id and in_bulk
@@ -2975,7 +2978,7 @@ class QuerySetTest(unittest.TestCase):
 
         pks = self.Person.objects.order_by('age').scalar('pk')[1:3]
         self.assertEqual(
-            "[u'A1', u'A2']",
+            six.text_type([u'A1', u'A2']),
             "%s" % sorted(
                 self.Person.objects.scalar('name').in_bulk(list(pks)).values()))
 

--- a/tests/queryset.py
+++ b/tests/queryset.py
@@ -564,44 +564,6 @@ class QuerySetTest(unittest.TestCase):
         obj_id = Blog.objects.insert(blog1, load_bulk=False)
         self.assertEquals(obj_id.__class__.__name__, 'ObjectId')
 
-    def test_slave_okay(self):
-        """Ensures that a query can take slave_okay syntax
-        """
-        person1 = self.Person(name="User A", age=20)
-        person1.save()
-        person2 = self.Person(name="User B", age=30)
-        person2.save()
-
-        # Retrieve the first person from the database
-        person = self.Person.objects.slave_okay(True).first()
-        self.assertTrue(isinstance(person, self.Person))
-        self.assertEqual(person.name, "User A")
-        self.assertEqual(person.age, 20)
-
-    def test_cursor_args(self):
-        """Ensures the cursor args can be set as expected
-        """
-        p = self.Person.objects
-        # Check default
-        self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': True})
-
-        p.snapshot(False).slave_okay(False).timeout(False)
-        self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': False})
-
-        p.snapshot(True).slave_okay(False).timeout(False)
-        self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': False, 'timeout': False})
-
-        p.snapshot(True).slave_okay(True).timeout(False)
-        self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': False})
-
-        p.snapshot(True).slave_okay(True).timeout(True)
-        self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': True})
-
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.
         """
@@ -2130,8 +2092,8 @@ class QuerySetTest(unittest.TestCase):
         group.reload()
 
         self.assertTrue(len(group.members) == 2)
-        self.assertEqual(group.members[0].name, user1.name)
-        self.assertEqual(group.members[1].name, user2.name)
+        self.assertEqual(group.members[0].id, user1.id)
+        self.assertEqual(group.members[1].id, user2.id)
 
         Group.drop_collection()
 
@@ -2210,7 +2172,7 @@ class QuerySetTest(unittest.TestCase):
                 return self.title
 
         Event.drop_collection()
-        Event.objects._collection.really_ensure_index(
+        Event.objects._collection.ensure_index(
                 [("location", pymongo.GEO2D)])
 
         event1 = Event(title="Coltrane Motion @ Double Door",
@@ -2307,7 +2269,7 @@ class QuerySetTest(unittest.TestCase):
             location = GeoPointField()
 
         Point.drop_collection()
-        Point.objects._collection.really_ensure_index(
+        Point.objects._collection.ensure_index(
                 [("location", pymongo.GEO2D)])
 
         # These points are one degree apart, which (according to Google Maps)

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
+import six
 from mongoengine import connect, Document, StringField
 from mongoengine import signals
 from mongoengine.connection import register_db, disconnect
@@ -92,11 +93,12 @@ class DocumentSignalTests(BaseSignalTests):
         connect()
         register_db('mongoenginetest')
 
+        @six.python_2_unicode_compatible
         class Author(Document):
             name = StringField()
 
-            def __unicode__(self):
-                return self.name
+            def __str__(self):
+                return str(self.name)
 
             @classmethod
             def pre_init(cls, sender, document, *args, **kwargs):
@@ -141,11 +143,12 @@ class DocumentSignalTests(BaseSignalTests):
                     signal_output.append('Not loaded')
         self.Author = Author
 
+        @six.python_2_unicode_compatible
         class Another(Document):
             name = StringField()
 
-            def __unicode__(self):
-                return self.name
+            def __str__(self):
+                return str(self.name)
 
             @classmethod
             def pre_init(cls, sender, document, **kwargs):

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -230,3 +230,7 @@ class SignalTests(unittest.TestCase):
         ])
 
         self.Author.objects.delete()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -81,7 +81,8 @@ class SignalTests(unittest.TestCase):
 
             @classmethod
             def pre_init(cls, sender, document, **kwargs):
-                signal_output.append('pre_init Another signal, %s' % cls.__name__)
+                signal_output.append(
+                    'pre_init Another signal, %s' % cls.__name__)
                 signal_output.append(str(kwargs['values']))
 
             @classmethod
@@ -107,11 +108,12 @@ class SignalTests(unittest.TestCase):
 
             @classmethod
             def post_delete(cls, sender, document, **kwargs):
-                signal_output.append('post_delete Another signal, %s' % document)
+                signal_output.append(
+                    'post_delete Another signal, %s' % document)
 
         self.Another = Another
-        # Save up the number of connected signals so that we can check at the end
-        # that all the signals we register get properly unregistered
+        # Save up the number of connected signals so that we can check at
+        # the end that all the signals we register get properly unregistered
         self.pre_signals = (
             len(signals.pre_init.receivers),
             len(signals.post_init.receivers),
@@ -174,7 +176,7 @@ class SignalTests(unittest.TestCase):
         """ Model saves should throw some signals. """
 
         def create_author():
-            a1 = self.Author(name='Bill Shakespeare')
+            self.Author(name='Bill Shakespeare')
 
         def bulk_create_author_with_load():
             a1 = self.Author(name='Bill Shakespeare')
@@ -198,7 +200,7 @@ class SignalTests(unittest.TestCase):
         ])
 
         a1.reload()
-        a1.name='William Shakespeare'
+        a1.name = 'William Shakespeare'
         self.assertEqual(self.get_signal_output(a1.save), [
             "pre_save signal, William Shakespeare",
             "post_save signal, William Shakespeare",
@@ -214,20 +216,22 @@ class SignalTests(unittest.TestCase):
 
         # The output of this signal is not entirely deterministic. The reloaded
         # object will have an object ID. Hence, we only check part of the output
-        self.assertEquals(signal_output[3],
+        self.assertEquals(
+            signal_output[3],
             "pre_bulk_insert signal, [<Author: Bill Shakespeare>]")
-        self.assertEquals(signal_output[-2:],
+        self.assertEquals(
+            signal_output[-2:],
             ["post_bulk_insert signal, [<Author: Bill Shakespeare>]",
-             "Is loaded",])
+             "Is loaded"])
 
-        self.assertEqual(self.get_signal_output(bulk_create_author_without_load), [
-            "pre_init signal, Author",
-            "{'name': 'Bill Shakespeare'}",
-            "post_init signal, Bill Shakespeare",
-            "pre_bulk_insert signal, [<Author: Bill Shakespeare>]",
-            "post_bulk_insert signal, [<Author: Bill Shakespeare>]",
-            "Not loaded",
-        ])
+        self.assertEqual(
+            self.get_signal_output(bulk_create_author_without_load),
+            ["pre_init signal, Author",
+             "{'name': 'Bill Shakespeare'}",
+             "post_init signal, Bill Shakespeare",
+             "pre_bulk_insert signal, [<Author: Bill Shakespeare>]",
+             "post_bulk_insert signal, [<Author: Bill Shakespeare>]",
+             "Not loaded"])
 
         self.Author.objects.delete()
 

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -287,10 +287,10 @@ class DocumentSignalTests(BaseSignalTests):
 
         # The output of this signal is not entirely deterministic. The reloaded
         # object will have an object ID. Hence, we only check part of the output
-        self.assertEquals(
+        self.assertEqual(
             signal_output[3],
             "pre_bulk_insert signal, [<Author: Bill Shakespeare>]")
-        self.assertEquals(
+        self.assertEqual(
             signal_output[-2:],
             ["post_bulk_insert signal, [<Author: Bill Shakespeare>]",
              "Is loaded"])

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from mongoengine import *
+from mongoengine import connect, Document, StringField
 from mongoengine import signals
 from mongoengine.connection import register_db
 
@@ -23,6 +23,7 @@ class SignalTests(unittest.TestCase):
     def setUp(self):
         connect()
         register_db('mongoenginetest')
+
         class Author(Document):
             name = StringField()
 
@@ -71,7 +72,6 @@ class SignalTests(unittest.TestCase):
                 else:
                     signal_output.append('Not loaded')
         self.Author = Author
-
 
         class Another(Document):
             name = StringField()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands = {envpython} setup.py test
+deps =


### PR DESCRIPTION
Although proper object ids should be coercable to str, passing in non-ascii unicode results in a less-than-useful exception message.

Also, validation did mask the actual underlying error with an opaque "Invalid Object ID" error

